### PR TITLE
fix: 增加更多分辨率预设选项

### DIFF
--- a/tools/registry/ModifyPCRegistry.ps1
+++ b/tools/registry/ModifyPCRegistry.ps1
@@ -36,11 +36,11 @@ param(
 
 # Centralized resolution presets
 $resolutionPresets = @(
-    @{ Label = 'a'; Number = '1'; Width = 3840; Height = 2160; Description = '3840 * 2160' }
-    @{ Label = 'b'; Number = '2'; Width = 2560; Height = 1440; Description = '2560 * 1440' }
-    @{ Label = 'c'; Number = '3'; Width = 1920; Height = 1080; Description = '1920 * 1080' }
-    @{ Label = 'd'; Number = '4'; Width = 1600; Height = 900; Description = '1600 * 900' }
-    @{ Label = 'e'; Number = '5'; Width = 1366; Height = 768; Description = '1366 * 768' }
+    @{ Label = 'a'; Number = '1'; Width = 3840; Height = 2160; Description = '3840 * 2160' },
+    @{ Label = 'b'; Number = '2'; Width = 2560; Height = 1440; Description = '2560 * 1440' },
+    @{ Label = 'c'; Number = '3'; Width = 1920; Height = 1080; Description = '1920 * 1080' },
+    @{ Label = 'd'; Number = '4'; Width = 1600; Height = 900; Description = '1600 * 900' },
+    @{ Label = 'e'; Number = '5'; Width = 1366; Height = 768; Description = '1366 * 768' },
     @{ Label = 'f'; Number = '6'; Width = 1280; Height = 720; Description = '1280 * 720' }
 )
 
@@ -159,7 +159,7 @@ if ($PSBoundParameters.Count -eq 0 -and -not $Restore) {
                     Clear-Host
                     Write-Host "Presets (will also set game defaults: windowed mode, zh_CN language):"
                     foreach ($res in $resolutionPresets) {
-                        Write-Host "  $($res.Label)) $($res.Description)"
+                        Write-Host "  $($res.Label): $($res.Description)"
                     }
                     Write-Host "  q) Return to main menu"
                     $presetLabels = ($resolutionPresets | ForEach-Object { $_.Label }) -join ', '


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

扩展注册表修改脚本的分辨率预设范围，并使预设映射与更多高分辨率选项保持一致。

新功能：
- 在交互式预设菜单和预设参数中新增 4K（3840x2160）和 2K（2560x1440）分辨率选项。
- enhancements':['将 PowerShell 参数验证集中允许的预设范围从四个增加到六个选项。']}]```

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

扩展基于注册表的分辨率修改脚本，增加更多预设和共享的预设定义，同时改进交互式菜单的用户体验和校验逻辑。

新功能：
- 为交互式和基于参数的预设选择都新增 4K (3840x2160) 和 2K (2560x1440) 分辨率选项。
- 支持 6 个数字预设参数，用于非交互式场景，并与扩展后的分辨率预设集合保持一致。

改进：
- 将分辨率预设定义集中到一个可复用的数据结构中，供交互式流程和预设参数流程共同使用。
- 改进交互式菜单，包括更清晰的提示、可循环的预设选择、返回主菜单的能力，以及更优雅的退出处理。
- 加强交互式还原流程中的校验和用户反馈，包括处理缺失备份文件和可选的还原后退出确认。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

扩展基于注册表的分辨率修改脚本，增加更多预设和共享预设处理，同时改进交互式菜单的用户体验以及还原流程的反馈。

新功能：
- 在预设列表和交互式预设菜单中新增 4K（3840x2160）和 2K（2560x1440）分辨率选项。
- 为非交互式使用场景提供与扩展后分辨率预设集对齐的六个数值预设参数支持。

增强改进：
- 将分辨率预设定义集中到可复用的数据结构中，以便在交互式流程和预设参数流程间共享。
- 改进交互式主菜单和预设菜单，提供更清晰的提示、循环选择能力，并允许在不退出脚本的情况下返回主菜单。
- 加强从备份还原的处理逻辑，提供更完善的校验、更好的用户反馈、可选的还原后退出确认，以及为提升可读性的短暂延时。

日常维护：
- 整理 PowerShell 脚本中的示例用法字符串，并移除过时的注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the registry-based resolution modification script with additional presets and shared preset handling while improving the interactive menu UX and restore flow feedback.

New Features:
- Add 4K (3840x2160) and 2K (2560x1440) resolution options to the preset list and interactive preset menu.
- Support six numeric preset parameters aligned with the expanded resolution preset set for non-interactive usage.

Enhancements:
- Centralize resolution preset definitions into a reusable data structure shared by interactive and preset-parameter flows.
- Improve the interactive main and preset menus with clearer prompts, looping selection, and the ability to return to the main menu without exiting.
- Enhance restore-from-backup handling with better validation, user feedback, optional post-restore exit confirmation, and brief delays for readability.

Chores:
- Tidy example usage strings and remove outdated comments in the PowerShell script.

</details>

</details>

新功能：
- 在用于基于注册表的分辨率更改的预设列表中，新增 4K (3840x2160) 和 2K (2560x1440) 分辨率选项。
- 支持与扩展后分辨率集合一致的六个数值型预设参数，用于非交互式使用。

增强点：
- 将分辨率预设定义集中到一个共享数据结构中，供交互式流程和基于参数的流程共同使用。
- 改进交互式菜单的用户体验，包含更清晰的提示、循环的预设选择器，以及在不中止程序的前提下返回主菜单的能力。
- 加强预设选择和备份还原路径的校验与错误处理，包括用户反馈和短暂延时。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

扩展基于注册表的分辨率修改脚本，增加更多预设和共享的预设定义，同时改进交互式菜单的用户体验和校验逻辑。

新功能：
- 为交互式和基于参数的预设选择都新增 4K (3840x2160) 和 2K (2560x1440) 分辨率选项。
- 支持 6 个数字预设参数，用于非交互式场景，并与扩展后的分辨率预设集合保持一致。

改进：
- 将分辨率预设定义集中到一个可复用的数据结构中，供交互式流程和预设参数流程共同使用。
- 改进交互式菜单，包括更清晰的提示、可循环的预设选择、返回主菜单的能力，以及更优雅的退出处理。
- 加强交互式还原流程中的校验和用户反馈，包括处理缺失备份文件和可选的还原后退出确认。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

扩展基于注册表的分辨率修改脚本，增加更多预设和共享预设处理，同时改进交互式菜单的用户体验以及还原流程的反馈。

新功能：
- 在预设列表和交互式预设菜单中新增 4K（3840x2160）和 2K（2560x1440）分辨率选项。
- 为非交互式使用场景提供与扩展后分辨率预设集对齐的六个数值预设参数支持。

增强改进：
- 将分辨率预设定义集中到可复用的数据结构中，以便在交互式流程和预设参数流程间共享。
- 改进交互式主菜单和预设菜单，提供更清晰的提示、循环选择能力，并允许在不退出脚本的情况下返回主菜单。
- 加强从备份还原的处理逻辑，提供更完善的校验、更好的用户反馈、可选的还原后退出确认，以及为提升可读性的短暂延时。

日常维护：
- 整理 PowerShell 脚本中的示例用法字符串，并移除过时的注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the registry-based resolution modification script with additional presets and shared preset handling while improving the interactive menu UX and restore flow feedback.

New Features:
- Add 4K (3840x2160) and 2K (2560x1440) resolution options to the preset list and interactive preset menu.
- Support six numeric preset parameters aligned with the expanded resolution preset set for non-interactive usage.

Enhancements:
- Centralize resolution preset definitions into a reusable data structure shared by interactive and preset-parameter flows.
- Improve the interactive main and preset menus with clearer prompts, looping selection, and the ability to return to the main menu without exiting.
- Enhance restore-from-backup handling with better validation, user feedback, optional post-restore exit confirmation, and brief delays for readability.

Chores:
- Tidy example usage strings and remove outdated comments in the PowerShell script.

</details>

</details>

</details>

</details>