### PR TITLE
fix: 将文档图片格式从PNG更改为WEBP

### DIFF
--- a/docs/en_us/manual/introduction.md
+++ b/docs/en_us/manual/introduction.md
@@ -38,11 +38,11 @@ The most useful roguelike mode for farming credits.
 
 #### Pinning Demonstration
 
-![Pinning Demonstration](/images/en-us/introduction-pin-example.png)
+![Pinning Demonstration](/images/en-us/introduction-pin-example.webp)
 
 #### Pinning Successful
 
-![Pinning Successful](/images/en-us/introduction-pin-success.png)
+![Pinning Successful](/images/en-us/introduction-pin-success.webp)
 
 ## Outside Deduction: The Syndrome Of Silence
 

--- a/docs/en_us/manual/newbie.md
+++ b/docs/en_us/manual/newbie.md
@@ -266,7 +266,7 @@ Can't change to `16:9` ratio when using the International Version PC client? Use
             <li>After opening, enter 1 in the command line</li>
             <li>As shown below</li>
           </ol>
-          <img src="/images/en-us/newbie-init-script-step1.png" alt="Step 1">
+          <img src="/images/en-us/newbie-init-script-step1.webp" alt="Step 1">
       </details>
     </li>
     <li>
@@ -276,7 +276,7 @@ Can't change to `16:9` ratio when using the International Version PC client? Use
             <li>Enter a/b/c/d according to the resolution you want to select</li>
             <li>As shown below</li>
           </ol>
-          <img src="/images/en-us/newbie-init-script-step2.png" alt="Step 2">
+          <img src="/images/en-us/newbie-init-script-step2.webp" alt="Step 2">
       </details>
     </li>
     </ul>
@@ -380,7 +380,7 @@ The following demonstrations are for reference only, please refer to the actual 
   <summary>MFA Main Interface Display</summary>
   <p></p>
   <blockquote>
-    <img src="/images/en-us/newbie-main-interface.png" alt="Main Interface">
+    <img src="/images/en-us/newbie-main-interface.webp" alt="Main Interface">
   </blockquote>
 </details>
 
@@ -432,7 +432,7 @@ Users using MFA update-related functions should configure `Update Settings`. Use
     <p></p>
     <blockquote>
       <ul>
-        <img src="/images/en-us/newbie-rate-limit.png" alt="rate limit exceeded">
+        <img src="/images/en-us/newbie-rate-limit.webp" alt="rate limit exceeded">
       </ul>
     </blockquote>
   </details>
@@ -507,7 +507,7 @@ Users using MFA update-related functions should configure `Update Settings`. Use
             <li>Click the icon to the right of the <code>Software Path</code> input box to enter the file selection interface, select the 1999 shortcut on the desktop, and the path will be automatically filled in.</li>
           </ol>
           <ul>
-            <img src="/images/en-us/newbie-emulator-path-example.png" alt="image_439">
+            <img src="/images/en-us/newbie-emulator-path-example.webp" alt="image_439">
           </ul>
       </details>
     </ul>
@@ -544,7 +544,7 @@ At least configure **`Resource Type`** and **`Connection`**. When configured inc
     <p></p>
     <blockquote>
       <ul>
-        <img src="/images/en-us/newbie-main-interface-connection.png" alt="image_440">
+        <img src="/images/en-us/newbie-main-interface-connection.webp" alt="image_440">
       </ul>
     </blockquote>
   </details>
@@ -583,7 +583,7 @@ When using the International Server PC client, simply click the PC icon in the c
     <p></p>
     <blockquote>
       <ul>
-        <img src="/images/en-us/newbie-main-interface-connection-pc.png" alt="connection-pc">
+        <img src="/images/en-us/newbie-main-interface-connection-pc.webp" alt="connection-pc">
       </ul>
     </blockquote>
   </details>
@@ -597,7 +597,7 @@ When using the International Server PC client, simply click the PC icon in the c
     <p></p>
     <blockquote>
       <ul>
-        <img src="/images/en-us/newbie-main-interface-task-lists.png" alt="image_441">
+        <img src="/images/en-us/newbie-main-interface-task-lists.webp" alt="image_441">
       </ul>
     </blockquote>
   </details>

--- a/docs/zh_cn/manual/introduction.md
+++ b/docs/zh_cn/manual/introduction.md
@@ -37,11 +37,11 @@ icon: mdi:information-outline
 
 #### 置顶演示
 
-![置顶演示](/images/zh-cn/introduction-pin-example.png)
+![置顶演示](/images/zh-cn/introduction-pin-example.webp)
 
 #### 置顶成功
 
-![置顶成功](/images/zh-cn/introduction-pin-success.png)
+![置顶成功](/images/zh-cn/introduction-pin-success.webp)
 
 ## 局外演绎：无声综合征
 

--- a/docs/zh_cn/manual/newbie.md
+++ b/docs/zh_cn/manual/newbie.md
@@ -267,7 +267,7 @@ M9A 支持主流模拟器与PC端，但您需要设置模拟器与PC端分辨率
             <li>打开后在命令行输入1</li>
             <li>如下图</li>
           </ol>
-          <img src="/images/zh-cn/newbie-init-script-step1.png" alt="步骤1">
+          <img src="/images/zh-cn/newbie-init-script-step1.webp" alt="步骤1">
       </details>
     </li>
     <li>
@@ -277,7 +277,7 @@ M9A 支持主流模拟器与PC端，但您需要设置模拟器与PC端分辨率
             <li>根据你要选择的分辨率选择输入a/b/c/d</li>
             <li>如下图</li>
           </ol>
-          <img src="/images/zh-cn/newbie-init-script-step2.png" alt="步骤2">
+          <img src="/images/zh-cn/newbie-init-script-step2.webp" alt="步骤2">
       </details>
     </li>
     </ul>
@@ -381,7 +381,7 @@ sudo xattr -rd com.apple.quarantine /usr/local/bin/M9A/*
   <summary>MFA主页面展示</summary>
   <p></p>
   <blockquote>
-    <img src="/images/zh-cn/newbie-main-interface.png" alt="主界面">
+    <img src="/images/zh-cn/newbie-main-interface.webp" alt="主界面">
   </blockquote>
 </details>
 
@@ -433,7 +433,7 @@ M9A 运行任务时，无法修改主界面的部分设置，如 `连接` 板块
     <p></p>
     <blockquote>
       <ul>
-        <img src="/images/zh-cn/newbie-rate-limit.png" alt="rate limit exceeded">
+        <img src="/images/zh-cn/newbie-rate-limit.webp" alt="rate limit exceeded">
       </ul>
     </blockquote>
   </details>
@@ -508,7 +508,7 @@ M9A 运行任务时，无法修改主界面的部分设置，如 `连接` 板块
             <li>点击 <code>软件路径</code> 输入框右侧图标进入文件选择界面，选择桌面上的 1999 快捷方式，路径将自动填入。</li>
           </ol>
           <ul>
-            <img src="/images/zh-cn/newbie-emulator-path-example.png" alt="image_439">
+            <img src="/images/zh-cn/newbie-emulator-path-example.webp" alt="image_439">
           </ul>
       </details>
     </ul>
@@ -545,7 +545,7 @@ M9A 运行任务时，无法修改主界面的部分设置，如 `连接` 板块
     <p></p>
     <blockquote>
       <ul>
-        <img src="/images/zh-cn/newbie-main-interface-connection.png" alt="image_440">
+        <img src="/images/zh-cn/newbie-main-interface-connection.webp" alt="image_440">
       </ul>
     </blockquote>
   </details>
@@ -584,7 +584,7 @@ M9A 运行任务时，无法修改主界面的部分设置，如 `连接` 板块
     <p></p>
     <blockquote>
       <ul>
-        <img src="/images/zh-cn/newbie-main-interface-connection-pc.png" alt="PC连接">
+        <img src="/images/zh-cn/newbie-main-interface-connection-pc.webp" alt="PC连接">
       </ul>
     </blockquote>
   </details>
@@ -598,7 +598,7 @@ M9A 运行任务时，无法修改主界面的部分设置，如 `连接` 板块
     <p></p>
     <blockquote>
       <ul>
-        <img src="/images/zh-cn/newbie-main-interface-task-lists.png" alt="image_441">
+        <img src="/images/zh-cn/newbie-main-interface-task-lists.webp" alt="image_441">
       </ul>
     </blockquote>
   </details>


### PR DESCRIPTION
## Summary by Sourcery

在英文和中文的新手手册及入门手册中，将文档中的图片引用从 PNG 格式更新为 WebP 格式。

文档：
- 将英文新手手册中引用的所有 PNG 截图切换为 WebP 版本。
- 将中文新手手册中引用的所有 PNG 截图切换为 WebP 版本。
- 将英文入门手册中关于固定操作演示和成功界面的截图更新为 WebP 图片。
- 将中文入门手册中关于固定操作演示和成功界面的截图更新为 WebP 图片。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation image references to use WebP format instead of PNG across newbie and introduction manuals in both English and Chinese.

Documentation:
- Switch all referenced PNG screenshots to WebP versions in the English newbie manual.
- Switch all referenced PNG screenshots to WebP versions in the Chinese newbie manual.
- Update pinning demonstration and success screenshots in the English introduction manual to use WebP images.
- Update pinning demonstration and success screenshots in the Chinese introduction manual to use WebP images.

</details>