### PR TITLE
fix: 调整StartGame点击区域

### DIFF
--- a/assets/resource/base/pipeline/startup.json
+++ b/assets/resource/base/pipeline/startup.json
@@ -78,9 +78,9 @@
             "type": "Click",
             "param": {
                 "target_offset": [
-                    -4,
+                    268,
                     296,
-                    0,
+                    -580,
                     -180
                 ]
             }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过在启动管道资源中更新配置来修复 StartGame 按钮的点击区域。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the StartGame button click region by updating its configuration in the startup pipeline resource.

</details>