### PR TITLE
fix: 适配当前版本复刻活动刷取

### DIFF
--- a/assets/resource/data/activity/cn.json
+++ b/assets/resource/data/activity/cn.json
@@ -599,20 +599,21 @@
                     },
                     "ActivityRe_releaseChapter": {
                         "recognition": {
-                            "type": "DirectHit",
+                            "type": "DirectHit"
+                        },
+                        "action": {
+                            "type": "Click",
                             "param": {
-                                "roi": [
+                                "target": [
                                     107,
                                     419,
                                     75,
                                     48
                                 ]
                             }
-                        },
-                        "action": "Click"
+                        }
                     }
                 }
             }
         }
     }
-}


### PR DESCRIPTION
用的DirectHit，当前ocr由于背景问题无法稳定识别初次进入菜单的活动名字，没有好的解决方案就DirectHit吧（还剩几天就活动没了

怎么现在活动那整这么复杂

## Summary by Sourcery

新功能：
- 引入 CN 活动配置项，以通过 DirectHit 逻辑支持刷取新的复刻活动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce CN activity configuration entries to support farming a new rerun event via DirectHit logic.

</details>