### PR TITLE
docs: 更新新手上路文档，增加对MXU的支持说明

### DIFF
--- a/docs/en_us/manual/newbie.md
+++ b/docs/en_us/manual/newbie.md
@@ -46,13 +46,13 @@ icon: ri:guide-fill
     </tr>
     <tr>
         <th><div align="center">CLI (MaaPiCli)</div></th>
-        <th><div align="center">GUI (MFAAvalonia)</div></th>
+        <th><div align="center">GUI (MFAA)</div></th>
         <th><div align="center">GUI (MXU)</div></th>
         <th><div align="center">CLI</div></th>
-        <th><div align="center">GUI</div></th>
+        <th><div align="center">GUI (MFAA)</div></th>
         <th><div align="center">GUI (MXU)</div></th>
         <th><div align="center">CLI</div></th>
-        <th><div align="center">GUI</div></th>
+        <th><div align="center">GUI (MFAA)</div></th>
         <th><div align="center">GUI (MXU)</div></th>
     </tr>
   </thead>

--- a/docs/zh_cn/manual/newbie.md
+++ b/docs/zh_cn/manual/newbie.md
@@ -46,13 +46,13 @@ icon: ri:guide-fill
     </tr>
     <tr>
         <th><div align="center">命令行（MaaPiCli）</div></th>
-        <th><div align="center">图形界面（MFAAvalonia）</div></th>
+        <th><div align="center">图形界面（MFAA）</div></th>
         <th><div align="center">图形界面（MXU）</div></th>
         <th><div align="center">命令行</div></th>
-        <th><div align="center">图形界面</div></th>
+        <th><div align="center">图形界面（MFAA）</div></th>
         <th><div align="center">图形界面（MXU）</div></th>
         <th><div align="center">命令行</div></th>
-        <th><div align="center">图形界面</div></th>
+        <th><div align="center">图形界面（MFAA）</div></th>
         <th><div align="center">图形界面（MXU）</div></th>
     </tr>
   </thead>


### PR DESCRIPTION
## Summary by Sourcery

更新新手指南文档，以同时涵盖 MFAAvalonia 和 MXU 跨平台图形界面，并澄清它们的使用方式。

文档：
- 在英文和中文新手指南中，将 MXU 与 MFAAvalonia 一同记录为受支持的 GUI 选项。
- 在新手指南中，为主界面、连接设置和任务列表部分添加 MXU 专用的界面说明和截图。
- 优化各平台的启动说明，以包含如何启动 MXU 可执行文件，并更新相关表述以提高清晰度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the newbie guide documentation to cover both MFAAvalonia and MXU graphical interfaces across platforms and clarify their usage.

Documentation:
- Document MXU alongside MFAAvalonia as a supported GUI option in the newbie guides for both English and Chinese.
- Add MXU-specific UI descriptions and screenshots for main interface, connection settings, and task list sections in the newbie guides.
- Refine platform-specific startup instructions to include launching the MXU executable and update related wording for clarity.

</details>