### PR TITLE
fix: 无声综合征第Ⅲ期修复部分事件卡住bug

### DIFF
--- a/assets/resource/base/pipeline/activity/TheSyndromeOfSilence.json
+++ b/assets/resource/base/pipeline/activity/TheSyndromeOfSilence.json
@@ -824,10 +824,12 @@
         "on_error": ["SOSNodeProcessErrorLoop"]
     },
     "SOSNodeProcessErrorLoop": {
+        // 处理节点选择或战斗过程中出现的错误
         "max_hit": 20,
         "next": [
             "SOSMain",
             "SOSSelectNoise",
+            "[JumpBack]SOSEventEnd",
             "[JumpBack]SOSGiveup",
             "[JumpBack]SOSStart",
             "[JumpBack]SOS_Skip",

--- a/assets/resource/base/pipeline/activity/TheSyndromeOfSilence.json
+++ b/assets/resource/base/pipeline/activity/TheSyndromeOfSilence.json
@@ -772,6 +772,7 @@
             "[JumpBack]SOSSelectArtefact",
             "[JumpBack]SOSArtefactsObtained",
             "[JumpBack]SOSSetOff",
+            "[JumpBack]SOSContinue",
             "[JumpBack]SOSSelectNode",
             "[JumpBack]SOSSelectHarmonic",
             "[JumpBack]SOSHarmonicObtained",
@@ -829,6 +830,7 @@
         "next": [
             "SOSMain",
             "SOSSelectNoise",
+            "[JumpBack]SOSContinue",
             "[JumpBack]SOSEventEnd",
             "[JumpBack]SOSGiveup",
             "[JumpBack]SOSStart",

--- a/assets/resource/data/sos/nodes.json
+++ b/assets/resource/data/sos/nodes.json
@@ -1232,8 +1232,7 @@
                 "actions": [
                     {
                         "type": "SelectOption",
-                        "method": "HSV",
-                        "index": -1
+                        "method": "HSV"
                     }
                 ],
                 "interrupts": "@message+@stats+@artefact+@harmonic+@resonator+@others"

--- a/assets/resource/data/sos/nodes.json
+++ b/assets/resource/data/sos/nodes.json
@@ -678,8 +678,7 @@
                 "actions": [
                     {
                         "type": "SelectOption",
-                        "method": "HSV",
-                        "index": -1
+                        "method": "HSV"
                     }
                 ],
                 "interrupts": "@message+@stats+@artefact+@harmonic+@resonator+@others"


### PR DESCRIPTION
## Summary by Sourcery

修复 “TheSyndromeOfSilence” 活动流水线及其关联的第三阶段 SOS 节点数据中的问题。

Bug 修复：
- 解决 TheSyndromeOfSilence 活动流水线配置中的错误。
- 更正 TheSyndromeOfSilence 使用的 SOS 节点数据定义中的不一致或错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix issues in the 'TheSyndromeOfSilence' activity pipeline and associated SOS node data for phase III.

Bug Fixes:
- Resolve bugs in the TheSyndromeOfSilence activity pipeline configuration.
- Correct inconsistencies or errors in SOS node data definitions used by TheSyndromeOfSilence.

</details>