### PR TITLE
feat: 新增必经之路事件通用结束消息点击 "SOSEventEndMessage"

### DIFF
--- a/assets/resource/base/pipeline/activity/TheSyndromeOfSilence.json
+++ b/assets/resource/base/pipeline/activity/TheSyndromeOfSilence.json
@@ -1308,6 +1308,27 @@
         },
         "post_wait_freezes": 500
     },
+    "SOSEventEndMessage": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    791,
+                    132,
+                    175,
+                    27
+                ],
+                "expected": [
+                    "结束事件"
+                ],
+                "only_rec": true
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "post_wait_freezes": 500
+    },
     "SOSCombat": {
         "recognition": {
             "type": "OCR",

--- a/assets/resource/data/sos/nodes.json
+++ b/assets/resource/data/sos/nodes.json
@@ -50,6 +50,7 @@
             "SOSDiceGiveUp",
             "SOSContinue",
             "SOSEventEnd",
+            "SOSEventEndMessage",
             "CloseTip"
         ],
         "EncounterAlongTheWay": "@stats+@artefact+@harmonic+@resonator+@others+@message_left+SOSClickEventRec",


### PR DESCRIPTION
用于解决一些必经之路事件的结束事件与偶现卡住

## Summary by Sourcery

新功能：
- 新增可复用的事件结束点击消息（`SOSEventEndMessage`），用于与 SOS 相关的活动和节点，以标准化事件结束行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add a reusable event end click message (SOSEventEndMessage) for SOS-related activities and nodes to standardize event termination behavior.

</details>