### PR TITLE
fix: 修复国际服唐人街影话活动复刻无法刷取问题

### DIFF
--- a/assets/resource/data/activity/en.json
+++ b/assets/resource/data/activity/en.json
@@ -443,6 +443,69 @@
                                 ]
                             }
                         }
+                    },
+                    "FlagInActivityStage": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1096,
+                                    597,
+                                    131,
+                                    41
+                                ]
+                            }
+                        }
+                    },
+                    "ActivityCombatStageNum": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1132,
+                                    55,
+                                    59,
+                                    62
+                                ],
+                                "expected": "0[1-9]|1[0-9]|2[0-2]"
+                            }
+                        }
+                    },
+                    "ActivityCombatStageCost": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    896,
+                                    591,
+                                    101,
+                                    54
+                                ]
+                            }
+                        }
+                    },
+                    "ActivityTargetLevel": {
+                        "attach": {
+                            "clicks": [
+                                [
+                                    939,
+                                    239
+                                ],
+                                [
+                                    1189,
+                                    242
+                                ]
+                            ]
+                        }
+                    },
+                    "ActivityTargetLevelRec": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1036,
+                                    231,
+                                    57,
+                                    26
+                                ]
+                            }
+                        }
                     }
                 }
             }

--- a/assets/resource/data/activity/jp.json
+++ b/assets/resource/data/activity/jp.json
@@ -443,6 +443,69 @@
                                 ]
                             }
                         }
+                    },
+                    "FlagInActivityStage": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1096,
+                                    597,
+                                    131,
+                                    41
+                                ]
+                            }
+                        }
+                    },
+                    "ActivityCombatStageNum": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1132,
+                                    55,
+                                    59,
+                                    62
+                                ],
+                                "expected": "0[1-9]|1[0-9]|2[0-2]"
+                            }
+                        }
+                    },
+                    "ActivityCombatStageCost": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    896,
+                                    591,
+                                    101,
+                                    54
+                                ]
+                            }
+                        }
+                    },
+                    "ActivityTargetLevel": {
+                        "attach": {
+                            "clicks": [
+                                [
+                                    939,
+                                    239
+                                ],
+                                [
+                                    1189,
+                                    242
+                                ]
+                            ]
+                        }
+                    },
+                    "ActivityTargetLevelRec": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1036,
+                                    231,
+                                    57,
+                                    26
+                                ]
+                            }
+                        }
                     }
                 }
             }

--- a/assets/resource/data/activity/tw.json
+++ b/assets/resource/data/activity/tw.json
@@ -260,6 +260,69 @@
                                 ]
                             }
                         }
+                    },
+                    "FlagInActivityStage": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1096,
+                                    597,
+                                    131,
+                                    41
+                                ]
+                            }
+                        }
+                    },
+                    "ActivityCombatStageNum": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1132,
+                                    55,
+                                    59,
+                                    62
+                                ],
+                                "expected": "0[1-9]|1[0-9]|2[0-2]"
+                            }
+                        }
+                    },
+                    "ActivityCombatStageCost": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    896,
+                                    591,
+                                    101,
+                                    54
+                                ]
+                            }
+                        }
+                    },
+                    "ActivityTargetLevel": {
+                        "attach": {
+                            "clicks": [
+                                [
+                                    939,
+                                    239
+                                ],
+                                [
+                                    1189,
+                                    242
+                                ]
+                            ]
+                        }
+                    },
+                    "ActivityTargetLevelRec": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    1036,
+                                    231,
+                                    57,
+                                    26
+                                ]
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
fixed #778

## Summary by Sourcery

Bug Fixes:
- 通过调整英文版和日文版的活动数据，修复了在国际版唐人街电影复刻活动中无法进行刷图/获取奖励的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix inability to farm/obtain rewards in the international Chinatown movie rerun event by adjusting EN/JP activity data.

</details>