### PR TITLE
fix: 修复部分角色动画时间过长导致（测试中）自动推图战斗异常结束；修复“再见，来亚什基”关卡间距较长导致识别不到下一关的问题

### DIFF
--- a/assets/resource/base/pipeline/activity/StagePromotion.json
+++ b/assets/resource/base/pipeline/activity/StagePromotion.json
@@ -201,7 +201,7 @@
                 "roi": [
                     681,
                     499,
-                    202,
+                    230,
                     133
                 ],
                 "expected": "\\d+"
@@ -270,7 +270,7 @@
                 ]
             }
         },
-        "post_delay": 5000
+        "post_delay": 8000
     },
     "StagePromotionCombatVictory": {
         "recognition": {


### PR DESCRIPTION
Fixes #783

<img width="1917" height="1083" alt="Screenshot 2026-05-21 151910" src="https://github.com/user-attachments/assets/7c7664a3-ad3c-4972-a969-2ef9126a5dd8" />

## Summary by Sourcery

调整关卡推进配置，以解决自动战斗异常结束和关卡进度检测的问题。

错误修复：
- 解决在关卡自动推进过程中，由于角色动画过长导致的自动战斗异常结束问题。
- 修复「再见，来亚什基」活动中的关卡间距问题，确保在推进过程中能够正确检测到下一关卡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust stage promotion configuration to address issues with automatic battle termination and stage progression detection.

Bug Fixes:
- Resolve abnormal auto-battle termination caused by overly long character animations during stage auto-push.
- Fix stage spacing in the '再见，来亚什基' activity so the next stage is correctly detected during progression.

</details>