### PR TITLE
fix: add Maa recognition type helpers

### DIFF
--- a/agent/custom/action/activity.py
+++ b/agent/custom/action/activity.py
@@ -6,6 +6,7 @@ from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_action import CustomAction
 from utils import logger, ms_timestamp_diff_to_dhm
+from utils.maa_types import ocr_text
 from utils.params import parse_params
 
 
@@ -391,7 +392,8 @@ class SailingRecordBoatSelect(CustomAction):
                     img,
                     {"SailingRecordBoatPointRecord": {"roi": roi_dices[i]}},
                 )
-                if best_choice.count(i) > int(reco_detail.best_result.text):
+                point = int(ocr_text(reco_detail))
+                if best_choice.count(i) > point:
                     context.run_task(
                         "SailingRecordBoatOp",
                         {
@@ -401,7 +403,7 @@ class SailingRecordBoatSelect(CustomAction):
                             }
                         },
                     )
-                elif best_choice.count(i) < int(reco_detail.best_result.text):
+                elif best_choice.count(i) < point:
                     context.run_task(
                         "SailingRecordBoatOp",
                         {

--- a/agent/custom/action/combat.py
+++ b/agent/custom/action/combat.py
@@ -1,13 +1,17 @@
 import re
 import time
+from typing import Any
 
 from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_action import CustomAction
 from utils import logger
+from utils.maa_types import boxed_results, is_hit, ocr_result, ocr_text
 from utils.params import parse_params
 
 # 尝试导入掉落识别模块（仅官方发布版可用）
+DropRecognitionState: Any = None
+run_drop_recognition: Any = None
 try:
     from libs.drop_core import (  # pyright: ignore[reportMissingImports]
         DropRecognitionState,
@@ -17,8 +21,6 @@ try:
     _DROP_RECOGNITION_AVAILABLE = True
 except ImportError:
     _DROP_RECOGNITION_AVAILABLE = False
-    DropRecognitionState = None
-    run_drop_recognition = None
     logger.warning("掉落识别模块不可用，掉落上报功能已禁用")
 
 
@@ -77,9 +79,8 @@ class PsychubeDoubleTimes(CustomAction):
             img,
         )
 
-        if reco_detail and reco_detail.hit:
-            best = getattr(reco_detail, "best_result", None)
-            text = getattr(best, "text", "") if best is not None else ""
+        if is_hit(reco_detail):
+            text = ocr_text(reco_detail)
             pattern = "(\\d)/4"
             m = re.search(pattern, text)
             if not m:
@@ -164,7 +165,7 @@ class TeamSelect(CustomAction):
             },
         )
 
-        if (reco_off_old and reco_off_old.hit) or (reco_open_old and reco_open_old.hit):
+        if is_hit(reco_off_old) or is_hit(reco_open_old):
             # 旧版
             target_list = [
                 [794, 406],
@@ -192,7 +193,7 @@ class TeamSelect(CustomAction):
                         }
                     },
                 )
-                if reco_open_old and reco_open_old.hit:
+                if is_hit(reco_open_old):
                     context.tasker.controller.post_click(target[0], target[1]).wait()
                     time.sleep(1)
                     flag = True
@@ -208,7 +209,7 @@ class TeamSelect(CustomAction):
                             }
                         },
                     )
-                    if reco_off_old and reco_off_old.hit:
+                    if is_hit(reco_off_old):
                         context.tasker.controller.post_click(965, 650).wait()
                         time.sleep(1)
         else:
@@ -224,7 +225,7 @@ class TeamSelect(CustomAction):
                     }
                 },
             )
-            if not (reco_off_new and reco_off_new.hit):
+            if not is_hit(reco_off_new):
                 logger.debug("未识别到队伍选择界面")
                 return CustomAction.RunResult(success=False)
             flag = False
@@ -247,21 +248,20 @@ class TeamSelect(CustomAction):
                         }
                     },
                 )
-                if reco_open_new and reco_open_new.hit:
+                if is_hit(reco_open_new):
                     # 识别到在队伍选择界面
                     time.sleep(2)  # 等待界面稳定
                     img = context.tasker.controller.post_screencap().wait().get()
                     reco_result = context.run_recognition("TeamListEditRoi", img)
                     if (
-                        reco_result is None
-                        or not reco_result.hit
+                        not is_hit(reco_result)
                         or not reco_result.filtered_results
                     ):
                         logger.error("未识别到成员队列")
                         return CustomAction.RunResult(success=False)
                     else:
                         # 识别到每个队伍左上角标志，获取每个队伍的名称和按键位置
-                        team_rois = reco_result.filtered_results
+                        team_rois = boxed_results(reco_result)
                         team_name_rois, team_confirm_rois = [], []
                         for team_roi in team_rois:
                             x, y, w, h = team_roi.box
@@ -284,19 +284,7 @@ class TeamSelect(CustomAction):
                                     }
                                 },
                             )
-                            if (
-                                reco_detail is None
-                                or not reco_detail.hit
-                                or not getattr(reco_detail, "best_result", None)
-                            ):
-                                team_name = ""
-                            else:
-                                best = getattr(reco_detail, "best_result", None)
-                                team_name = (
-                                    getattr(best, "text", "")
-                                    if best is not None
-                                    else ""
-                                )
+                            team_name = ocr_text(reco_detail)
                             if team_name not in team_names:
                                 team_names.append(team_name)
                             # 队伍名称为新增，识别使用&使用中状态
@@ -315,25 +303,13 @@ class TeamSelect(CustomAction):
                                     }
                                 },
                             )
-                            if (
-                                reco_detail is None
-                                or not reco_detail.hit
-                                or not getattr(reco_detail, "best_result", None)
-                            ):
+                            team_use_result = ocr_result(reco_detail)
+                            if not is_hit(reco_detail) or team_use_result is None:
                                 team_use_text = ""
                                 team_use_roi = None
                             else:
-                                best = getattr(reco_detail, "best_result", None)
-                                team_use_text = (
-                                    getattr(best, "text", "")
-                                    if best is not None
-                                    else ""
-                                )
-                                team_use_roi = (
-                                    getattr(best, "box", None)
-                                    if best is not None
-                                    else None
-                                )
+                                team_use_text = team_use_result.text
+                                team_use_roi = team_use_result.box
                             team_use_status = -1
                             if "使用中" in team_use_text:
                                 team_use_status = 1
@@ -384,7 +360,7 @@ class TeamSelect(CustomAction):
                                             }
                                         },
                                     )
-                                    if reco_open_new is None or not reco_open_new.hit:
+                                    if not is_hit(reco_open_new):
                                         # 已退出选择界面
                                         flag = True
                                         break
@@ -412,7 +388,7 @@ class TeamSelect(CustomAction):
                                         "ReadyForAction", img
                                     )
 
-                                    if reco_detail and reco_detail.hit:
+                                    if is_hit(reco_detail):
                                         break
 
                                 flag = True
@@ -429,7 +405,7 @@ class TeamSelect(CustomAction):
                             }
                         },
                     )
-                    if reco_off_new and reco_off_new.hit:
+                    if is_hit(reco_off_new):
                         # 识别到不在队伍选择界面，点击打开
                         context.tasker.controller.post_click(965, 650).wait()
                         time.sleep(1)
@@ -463,12 +439,7 @@ class CombatTargetLevel(CustomAction):
         img = context.tasker.controller.post_screencap().wait().get()
         reco_detail = context.run_recognition("TargetLevelRec", img)
 
-        best = (
-            getattr(reco_detail, "best_result", None)
-            if reco_detail and reco_detail.hit
-            else None
-        )
-        reco_text = getattr(best, "text", "") if best is not None else ""
+        reco_text = ocr_text(reco_detail)
         if not reco_text or not any(
             difficulty in reco_text for difficulty in valid_levels
         ):
@@ -526,12 +497,7 @@ class ActivityTargetLevel(CustomAction):
         img = context.tasker.controller.post_screencap().wait().get()
         reco_detail = context.run_recognition("ActivityTargetLevelRec", img)
 
-        best = (
-            getattr(reco_detail, "best_result", None)
-            if reco_detail and reco_detail.hit
-            else None
-        )
-        reco_text = getattr(best, "text", "") if best is not None else ""
+        reco_text = ocr_text(reco_detail)
         if not reco_text or not any(
             difficulty in reco_text for difficulty in valid_levels
         ):
@@ -568,11 +534,7 @@ class ActivityTargetLevel(CustomAction):
             img = context.tasker.controller.post_screencap().wait().get()
             reco_detail = context.run_recognition("ActivityTargetLevelRec", img)
 
-            if reco_detail and reco_detail.hit:
-                best = getattr(reco_detail, "best_result", None)
-                cur_level = getattr(best, "text", "") if best is not None else None
-            else:
-                cur_level = None
+            cur_level = ocr_text(reco_detail) or None
 
         return CustomAction.RunResult(success=True)
 
@@ -614,7 +576,7 @@ class SelectChapter(CustomAction):
                     }
                 },
             )
-            if rec is None or not getattr(rec, "hit", False) or count >= 5:
+            if not is_hit(rec) or count >= 5:
                 flag = True
 
         return CustomAction.RunResult(success=True)
@@ -748,10 +710,11 @@ def _tc_safe_int(text: str) -> int:
 
 def _tc_get_text_safe(context: Context, img, rec_name: str) -> str:
     rec = context.run_recognition(rec_name, img)
-    if rec is None or getattr(rec, "best_result", None) is None:
+    text = ocr_text(rec)
+    if not text:
         logger.debug(f"{rec_name} 识别失败，返回None")
         return "0"
-    return getattr(rec.best_result, "text", "0") or "0"
+    return text
 
 
 def _tc_get_available_count(context: Context) -> int:
@@ -1008,7 +971,7 @@ class SSReopenReplay(CustomAction):
         # 开始刷图
         img = context.tasker.controller.cached_image
         reco_detail = context.run_recognition("SSCannotReplay", img)
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             # 无法复现，直接开始任务
             context.run_task("SSNoReplay")
         else:

--- a/agent/custom/action/complete_induction.py
+++ b/agent/custom/action/complete_induction.py
@@ -8,6 +8,7 @@ from maa.context import Context
 from maa.custom_action import CustomAction
 from maa.pipeline import JOCR, JColorMatch, JRecognitionType, JTemplateMatch
 from utils import logger
+from utils.maa_types import is_hit, ocr_text
 
 _CATEGORY_UNLOCK_LEVEL: dict[str, int] = {
     "理性构成": 0,
@@ -609,8 +610,8 @@ class CIRecordLevel(CustomAction):
             JOCR(roi=self._level_roi, expected=["[1]?[0-9]+"]),
             img,
         )
-        if reco_detail and reco_detail.hit:
-            CIRecord.level = int(reco_detail.best_result.text.strip())
+        if is_hit(reco_detail):
+            CIRecord.level = int(ocr_text(reco_detail).strip())
             logger.info(f"当前研究所等级: {CIRecord.level}")
         else:
             logger.error("未识别出研究所等级")
@@ -636,7 +637,7 @@ class CITask(CustomAction):
             JOCR(roi=self._task_roi, order_by="Vertical"),
             img,
         )
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             text_items: list[str] = []
             for item in getattr(reco_detail, "filtered_results", []) or []:
                 text = (getattr(item, "text", "") or "").strip()
@@ -706,7 +707,7 @@ class CITask(CustomAction):
         roi: tuple[int, int, int, int],
         desired_selected: bool,
     ) -> bool:
-        for attempt in range(3):
+        for _attempt in range(3):
             is_selected = self._is_option_selected(context, roi)
             if is_selected == desired_selected:
                 logger.info(
@@ -737,7 +738,7 @@ class CITask(CustomAction):
             ),
             img,
         )
-        return bool(reco_detail and reco_detail.hit)
+        return is_hit(reco_detail)
 
 
 @AgentServer.custom_action("CIRecordPeopleMaxCount")
@@ -760,7 +761,7 @@ class CIRecordPeopleMaxCount(CustomAction):
             ),
             img,
         )
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             CIRecord.researcher_max_count = len(reco_detail.filtered_results)
             logger.info(f"当前最多可参与研究的人数: {CIRecord.researcher_max_count}")
 
@@ -1144,7 +1145,7 @@ class CISelectResearchers(CustomAction):
                 ),
                 img,
             )
-            return bool(reco_detail and reco_detail.hit)
+            return is_hit(reco_detail)
 
         if spec.kind == "ocr":
             reco_detail = context.run_recognition_direct(
@@ -1155,7 +1156,7 @@ class CISelectResearchers(CustomAction):
                 ),
                 img,
             )
-            return bool(reco_detail and reco_detail.hit)
+            return is_hit(reco_detail)
 
         if spec.kind == "color":
             reco_detail = context.run_recognition_direct(
@@ -1169,7 +1170,7 @@ class CISelectResearchers(CustomAction):
                 ),
                 img,
             )
-            return bool(reco_detail and reco_detail.hit)
+            return is_hit(reco_detail)
 
         logger.error(f"未知研究员识别类型: {spec.kind}")
         return False
@@ -1186,10 +1187,10 @@ class CISelectResearchers(CustomAction):
             ),
             img,
         )
-        if reco_detail is None or not reco_detail.hit:
+        if not is_hit(reco_detail):
             return None
 
-        text = getattr(reco_detail.best_result, "text", "") or ""
+        text = ocr_text(reco_detail)
         digits = re.sub(r"[^\d]", "", text)
         if not digits:
             return None

--- a/agent/custom/action/critter_crash.py
+++ b/agent/custom/action/critter_crash.py
@@ -5,6 +5,7 @@ from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_action import CustomAction
 from utils import logger
+from utils.maa_types import is_hit, ocr_text
 
 
 @AgentServer.custom_action("CCChessboard")
@@ -165,7 +166,11 @@ class CCChessboard(CustomAction):
         if chess is None:
             return False
 
-        chess_info = cls.get_chess_info(chess["name"])
+        name = chess["name"]
+        if not isinstance(name, str):
+            return False
+
+        chess_info = cls.get_chess_info(name)
         if chess["level"] >= chess_info.get("max_level", 1):
             return False  # 已达最高等级
 
@@ -349,7 +354,7 @@ class CCBuyCard(CustomAction):
                         img,
                         pipeline_override={"CCLevelMax": {"roi": roi_max}},
                     )
-                    if level_max_reco and level_max_reco.hit:
+                    if is_hit(level_max_reco):
                         max_level = CCChessboard.get_chess_info(card_name).get(
                             "max_level", 1
                         )
@@ -455,9 +460,9 @@ class CCLevelUp(CustomAction):
             reco_detail = context.run_recognition(
                 "CCLevelRec", context.tasker.controller.cached_image
             )
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 # 识别到文字，判断等级
-                current_level = int(reco_detail.best_result.text)
+                current_level = int(ocr_text(reco_detail))
                 if current_level > self.level:
                     logger.debug(
                         f"检测到升级，从 {self.level} 升级到 {current_level}，等待中..."

--- a/agent/custom/action/eight_bit.py
+++ b/agent/custom/action/eight_bit.py
@@ -6,6 +6,7 @@ from maa.context import Context
 from maa.custom_action import CustomAction
 from maa.pipeline import JOCR, JRecognitionType, JTemplateMatch
 from utils import logger
+from utils.maa_types import best_box, boxed_results, is_hit, ocr_text
 from utils.params import parse_params
 
 KEYCODE_DPAD_UP = 19
@@ -86,14 +87,14 @@ class EightBitCombatInit(CustomAction):
             img,
         )
 
-        if reco_boss and reco_boss.hit:
+        if is_hit(reco_boss):
             logger.debug("[8bit] 识别到 Boss，退出到主页面")
             context.run_task("8bitExit")
             return CustomAction.RunResult(success=True)
 
-        EightBitCombatInit.wall_detection_enabled = (
-            reco_bottom is not None and reco_bottom.hit
-        ) or (reco_tp is not None and reco_tp.hit)
+        EightBitCombatInit.wall_detection_enabled = is_hit(reco_bottom) or is_hit(
+            reco_tp
+        )
         if EightBitCombatInit.wall_detection_enabled:
             logger.debug("[8bit] 开启碰壁检测")
 
@@ -303,8 +304,8 @@ class EightBitCombatMove(CustomAction):
             img,
         )
 
-        if reco_tp and reco_tp.hit and reco_tp.best_result:
-            box = reco_tp.best_result.box
+        box = best_box(reco_tp)
+        if box is not None:
             return (box[0] + box[2] // 2, box[1] + box[3] // 2)
 
         return None
@@ -322,27 +323,28 @@ class EightBitCombatMove(CustomAction):
             img,
         )
 
-        if reco_people and reco_people.hit and reco_people.filtered_results:
-            if len(reco_people.filtered_results) == 1:
-                box = reco_people.filtered_results[0].box
+        results = boxed_results(reco_people)
+        if results:
+            if len(results) == 1:
+                box = results[0].box
                 return (box[0] + box[2] // 2, box[1] + box[3] // 2)
 
             # 多个结果时，根据上一次移动方向选择
             if EightBitCombatMove._last_move_key == KEYCODE_DPAD_RIGHT:
                 # 上次往右，选最左边的
-                best = min(reco_people.filtered_results, key=lambda r: r.box[0])
+                best = min(results, key=lambda r: r.box[0])
             elif EightBitCombatMove._last_move_key == KEYCODE_DPAD_LEFT:
                 # 上次往左，选最右边的
-                best = max(reco_people.filtered_results, key=lambda r: r.box[0])
+                best = max(results, key=lambda r: r.box[0])
             elif EightBitCombatMove._last_move_key == KEYCODE_DPAD_DOWN:
                 # 上次往下，选最上面的
-                best = min(reco_people.filtered_results, key=lambda r: r.box[1])
+                best = min(results, key=lambda r: r.box[1])
             elif EightBitCombatMove._last_move_key == KEYCODE_DPAD_UP:
                 # 上次往上，选最下面的
-                best = max(reco_people.filtered_results, key=lambda r: r.box[1])
+                best = max(results, key=lambda r: r.box[1])
             else:
                 # 没有上次操作，默认选第一个
-                best = reco_people.filtered_results[0]
+                best = results[0]
 
             box = best.box
             return (box[0] + box[2] // 2, box[1] + box[3] // 2)
@@ -396,14 +398,14 @@ class EightBitScoreRecord(CustomAction):
             img,
         )
 
-        if not (score_detail and score_detail.hit):
+        if not is_hit(score_detail):
             logger.warning("[8bit] 未识别到获得代币")
             context.tasker.controller.post_click(
                 700, 600
             ).wait()  # 点击空白处关闭可能的弹窗
             return CustomAction.RunResult(success=True)
 
-        current_score = int(score_detail.best_result.text)
+        current_score = int(ocr_text(score_detail))
         current_time = time.time()
         self._record_count += 1
 

--- a/agent/custom/action/lucidscape.py
+++ b/agent/custom/action/lucidscape.py
@@ -5,6 +5,7 @@ from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_action import CustomAction
 from utils import logger
+from utils.maa_types import is_hit, ocr_text
 from utils.params import parse_params
 
 
@@ -42,10 +43,10 @@ class LucidscapeStageSelect(CustomAction):
                 img,
                 {"LucidscapeStageLocked": {"expected": f"\\d/{max}", "roi": roi}},
             )
-            if reco_detail is None or not reco_detail.hit:
+            if not is_hit(reco_detail):
                 return CustomAction.RunResult(success=False)
             pattern = f"(\\d{{1,3}})/{max}"
-            text = reco_detail.best_result.text
+            text = ocr_text(reco_detail)
             logger.debug(f"text: {text}")
             match = re.search(pattern, text)
             if match:
@@ -96,7 +97,7 @@ class LucidscapeStatusDetect(CustomAction):
 
         # Finish
         reco_detail = context.run_recognition("LucidscapeFinish", img)
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             logger.info(f"醒梦片段·{self._int2RomanNumeral(stage)}已完成")
             logger.info("领取本层酬劳")
             if stage == 4:
@@ -116,7 +117,7 @@ class LucidscapeStatusDetect(CustomAction):
 
         # StageFlag02
         reco_detail = context.run_recognition("LucidscapeStageFlag02", img)
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             context.tasker.controller.post_click(990, 300).wait()
             context.override_next(
                 "LucidscapeCombatStartFlag", ["LucidscapeTeamSelect_2"]
@@ -126,7 +127,7 @@ class LucidscapeStatusDetect(CustomAction):
 
         # StageFlag01
         reco_detail = context.run_recognition("LucidscapeStageFlag01", img)
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             context.tasker.controller.post_click(320, 445).wait()
             context.override_next(
                 "LucidscapeCombatStartFlag", ["LucidscapeTeamSelect_1"]

--- a/agent/custom/action/outside_deduction.py
+++ b/agent/custom/action/outside_deduction.py
@@ -4,6 +4,7 @@ from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_action import CustomAction
 from utils import logger
+from utils.maa_types import is_hit, ocr_text
 from utils.params import parse_params
 
 
@@ -28,9 +29,9 @@ class SOD_DifficultySelect(CustomAction):
 
         img = context.tasker.controller.post_screencap().wait().get()
         reco_detail = context.run_recognition("SOD_CurrentLevel", img)
-        if reco_detail is None or not reco_detail.hit:
+        if not is_hit(reco_detail):
             return CustomAction.RunResult(success=False)
-        cur = int(reco_detail.best_result.text)
+        cur = int(ocr_text(reco_detail))
 
         if level == "cur":
             logger.info(f"选定当前难度 {cur}")
@@ -42,12 +43,12 @@ class SOD_DifficultySelect(CustomAction):
             level = int(level)
             if cur > level:
                 delta = cur - level
-                for i in range(delta):
+                for _i in range(delta):
                     context.tasker.controller.post_click(20, 360).wait()
                     time.sleep(0.5)
             else:
                 delta = level - cur
-                for i in range(delta):
+                for _i in range(delta):
                     context.tasker.controller.post_click(1260, 360).wait()
                     time.sleep(0.5)
         else:
@@ -64,14 +65,14 @@ class SOD_DifficultySelect(CustomAction):
             img = context.tasker.controller.post_screencap().wait().get()
             reco_detail = context.run_recognition("SOD_LevelLocked", img)
 
-            while reco_detail is None or not reco_detail.hit:
+            while not is_hit(reco_detail):
                 context.tasker.controller.post_click(1260, 360).wait()
                 time.sleep(0.5)
                 img = context.tasker.controller.post_screencap().wait().get()
                 reco_detail = context.run_recognition("SOD_LevelLocked", img)
 
             # To UnLocked Level
-            while reco_detail is not None and reco_detail.hit:
+            while is_hit(reco_detail):
                 context.tasker.controller.post_click(20, 360).wait()
                 time.sleep(0.5)
                 img = context.tasker.controller.post_screencap().wait().get()
@@ -79,9 +80,9 @@ class SOD_DifficultySelect(CustomAction):
 
         img = context.tasker.controller.post_screencap().wait().get()
         reco_detail = context.run_recognition("SOD_CurrentLevel", img)
-        if reco_detail is None or not reco_detail.hit:
+        if not is_hit(reco_detail):
             return CustomAction.RunResult(success=False)
-        cur = int(reco_detail.best_result.text)
+        cur = int(ocr_text(reco_detail))
 
         context.override_pipeline({"ODR_FlagInDifficultySelect": {"enabled": False}})
         logger.info(f"选定难度 {cur}")

--- a/agent/custom/action/record_id.py
+++ b/agent/custom/action/record_id.py
@@ -3,6 +3,7 @@ from maa.context import Context
 from maa.custom_action import CustomAction
 from maa.pipeline import JOCR, JRecognitionType
 from utils import logger
+from utils.maa_types import ocr_text
 
 
 @AgentServer.custom_action("RecordID")
@@ -31,9 +32,8 @@ class RecordID(CustomAction):
             JOCR(roi=self._user_name_roi, only_rec=True),
             img,
         )
-        if reco_detail and reco_detail.hit:
-            user_name = reco_detail.best_result.text.strip()
-        else:
+        user_name = ocr_text(reco_detail).strip()
+        if not user_name:
             logger.info("未识别到用户名文本")
 
         reco_detail = context.run_recognition_direct(
@@ -41,9 +41,8 @@ class RecordID(CustomAction):
             JOCR(roi=self._id_roi, only_rec=True),
             img,
         )
-        if reco_detail and reco_detail.hit:
-            account_id = reco_detail.best_result.text.strip()
-        else:
+        account_id = ocr_text(reco_detail).strip()
+        if not account_id:
             logger.info("未识别到ID文本")
 
         if user_name != RecordID.global_user_name or account_id != RecordID.global_id:

--- a/agent/custom/action/reward.py
+++ b/agent/custom/action/reward.py
@@ -3,6 +3,7 @@ from maa.context import Context
 from maa.custom_action import CustomAction
 from maa.pipeline import JOCR, JActionType, JClick, JRecognitionType
 from utils import logger
+from utils.maa_types import is_hit
 
 
 @AgentServer.custom_action("RewardHandler")
@@ -28,7 +29,7 @@ class RewardHandler(CustomAction):
             img,
         )
 
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             text_items: list[str] = []
             for item in getattr(reco_detail, "filtered_results", []) or []:
                 text = (getattr(item, "text", "") or "").strip()

--- a/agent/custom/action/switch_account.py
+++ b/agent/custom/action/switch_account.py
@@ -7,6 +7,7 @@ from maa.context import Context
 from maa.custom_action import CustomAction
 from maa.pipeline import JOCR, JRecognitionType
 from utils import logger
+from utils.maa_types import boxed_results, is_hit, ocr_text
 from utils.params import parse_params
 
 __all__ = ["SwitchAccountSelect"]
@@ -129,14 +130,13 @@ class SwitchAccountSelect(CustomAction):
         return []
 
     def _extract_boxes(self, reco_detail) -> list[tuple[int, int, int, int]]:
-        if reco_detail is None or not reco_detail.hit:
+        if not is_hit(reco_detail):
             return []
 
         boxes: list[tuple[int, int, int, int]] = []
-        for result in getattr(reco_detail, "filtered_results", []) or []:
-            box = getattr(result, "box", None)
-            if box:
-                boxes.append((int(box[0]), int(box[1]), int(box[2]), int(box[3])))
+        for result in boxed_results(reco_detail):
+            box = result.box
+            boxes.append((int(box[0]), int(box[1]), int(box[2]), int(box[3])))
 
         if not boxes:
             best = getattr(reco_detail, "best_result", None)
@@ -165,7 +165,7 @@ class SwitchAccountSelect(CustomAction):
             JOCR(roi=row_roi, order_by="Vertical"),
             img,
         )
-        if reco_detail is None or not reco_detail.hit:
+        if not is_hit(reco_detail):
             return ""
 
         texts: list[str] = []
@@ -175,8 +175,7 @@ class SwitchAccountSelect(CustomAction):
                 texts.append(text)
 
         if not texts:
-            best = getattr(reco_detail, "best_result", None)
-            text = (getattr(best, "text", "") or "").strip() if best is not None else ""
+            text = ocr_text(reco_detail).strip()
             if text:
                 texts.append(text)
 

--- a/agent/custom/action/syndrome_of_silence.py
+++ b/agent/custom/action/syndrome_of_silence.py
@@ -404,6 +404,7 @@ class SOSNodeProcess(CustomAction):
 
                 img = context.tasker.controller.post_screencap().wait().get()
                 reco_detail = context.run_recognition(name, img)
+                # DirectHit nodes are executable even when Maa does not provide a box.
                 if is_hit(reco_detail) or (
                     reco_detail is not None and reco_detail.algorithm == "DirectHit"
                 ):

--- a/agent/custom/action/syndrome_of_silence.py
+++ b/agent/custom/action/syndrome_of_silence.py
@@ -5,15 +5,15 @@ import json
 import os
 import re
 import time
-from typing import cast
 
 import numpy as np
 from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_action import CustomAction
-from maa.define import NeuralNetworkDetectResult, OCRResult
+from maa.define import NeuralNetworkDetectResult
 from PIL import Image
 from utils import logger
+from utils.maa_types import is_hit, ocr_text
 from utils.params import parse_params
 
 __all__ = [
@@ -167,7 +167,7 @@ class SOSSelectNode(CustomAction):
             )
             img = context.tasker.controller.post_screencap().wait().get()
             rec = context.run_recognition("SOSGOTO", img)
-            if rec and rec.hit:
+            if is_hit(rec):
                 context.run_task("SOSGOTO")
                 break
             times += 1
@@ -184,9 +184,8 @@ class SOSSelectNode(CustomAction):
                     "SOSEventRec", img, {"SOSEventRec": {"roi": event_name_roi}}
                 )
 
-                if reco_detail and reco_detail.hit:
-                    ocr_result = cast(OCRResult, reco_detail.best_result)
-                    event = ocr_result.text
+                if is_hit(reco_detail):
+                    event = ocr_text(reco_detail)
                     SOSSelectNode.event_name = event
                     logger.info(f"当前事件: {event}")
                     break
@@ -212,7 +211,7 @@ class SOSSelectNode(CustomAction):
 
                     for interrupt in interrupts:
                         rec = context.run_recognition(interrupt, img)
-                        if rec and rec.hit:
+                        if is_hit(rec):
                             logger.debug(f"检测到弹窗，执行节点: {interrupt}")
                             context.run_task(interrupt)
                             retry_times = 0
@@ -227,7 +226,7 @@ class SOSSelectNode(CustomAction):
                 # 事件名识别失败，检查是否是购物契机被误识别为其他节点
                 img = context.tasker.controller.post_screencap().wait().get()
                 shopping_rec = context.run_recognition("SOSShopping", img)
-                if shopping_rec and shopping_rec.hit:
+                if is_hit(shopping_rec):
                     logger.warning(
                         f"节点类型 {node_type} 事件名识别失败，"
                         f"但检测到购物契机界面，修正节点类型"
@@ -382,7 +381,7 @@ class SOSNodeProcess(CustomAction):
         if isinstance(action, str):
             img = context.tasker.controller.post_screencap().wait().get()
             rec = context.run_recognition(action, img)
-            if rec and rec.hit:
+            if is_hit(rec):
                 logger.debug(f"执行中断节点: {action}")
                 context.run_task(action)
                 return True
@@ -405,11 +404,8 @@ class SOSNodeProcess(CustomAction):
 
                 img = context.tasker.controller.post_screencap().wait().get()
                 reco_detail = context.run_recognition(name, img)
-                if (
-                    reco_detail
-                    and reco_detail.hit
-                    or reco_detail
-                    and reco_detail.algorithm == "DirectHit"
+                if is_hit(reco_detail) or (
+                    reco_detail is not None and reco_detail.algorithm == "DirectHit"
                 ):
                     logger.debug(f"执行节点: {name}")
                     context.run_task(entry=name)
@@ -420,7 +416,7 @@ class SOSNodeProcess(CustomAction):
 
                 img = context.tasker.controller.post_screencap().wait().get()
                 check_reco = context.run_recognition("SOSSelectOption", img)
-                if not check_reco or not check_reco.hit:
+                if not is_hit(check_reco):
                     return False
 
                 method = action.get("method", "HSV")
@@ -498,7 +494,7 @@ class SOSNodeProcess(CustomAction):
                     check_reco = context.run_recognition(
                         "SOSSelectEncounterOptionRec_Template", img
                     )
-                    if not check_reco or not check_reco.hit:
+                    if not is_hit(check_reco):
                         logger.debug("未识别到途中偶遇选项界面，跳过")
                         return False
 
@@ -532,7 +528,7 @@ class SOSNodeProcess(CustomAction):
                     check_reco = context.run_recognition(
                         "SOSSelectEncounterOptionRec_Template", img
                     )
-                    if not check_reco or not check_reco.hit:
+                    if not is_hit(check_reco):
                         logger.debug("未识别到途中偶遇选项界面，跳过")
                         return False
 
@@ -670,7 +666,7 @@ class SOSShoppingList(CustomAction):
             processed_img[mask] = img[mask]
 
             reco_detail = context.run_recognition("SOSShoppingListOCR", processed_img)
-            if not reco_detail or not reco_detail.hit:
+            if not is_hit(reco_detail):
                 retry_times += 1
                 continue
 
@@ -779,7 +775,7 @@ class SOSShoppingList(CustomAction):
                 },
             )
 
-            if sold_out_reco and sold_out_reco.hit:
+            if is_hit(sold_out_reco):
                 logger.debug(f"跳过已售出物品: {current_text}")
                 skipped.add(current_text)
                 i += 1
@@ -878,12 +874,11 @@ class SOSBuyItems(CustomAction):
             {"OCR": {"recognition": "OCR", "roi": money_roi, "expected": r"\d{1,5}"}},
         )
 
-        if not reco_detail or not reco_detail.hit:
+        if not is_hit(reco_detail):
             logger.error("无法识别当前金雀子儿")
             return CustomAction.RunResult(success=False)
 
-        ocr_result = cast(OCRResult, reco_detail.best_result)
-        money_text = ocr_result.text
+        money_text = ocr_text(reco_detail)
 
         # 提取数字
         money_match = re.search(r"\d+", money_text)
@@ -937,7 +932,7 @@ class SOSBuyItems(CustomAction):
             img = context.tasker.controller.post_screencap().wait().get()
             reco_detail = context.run_recognition("SOSShoppingListOCR", img)
 
-            if not reco_detail or not reco_detail.hit:
+            if not is_hit(reco_detail):
                 page_index += 1
                 context.run_task(
                     "Swipe",
@@ -986,7 +981,7 @@ class SOSBuyItems(CustomAction):
 
             # 获取可见价格的物品名集合（金雀子儿足够的物品）
             affordable_items = set()
-            if price_reco_detail and price_reco_detail.hit:
+            if is_hit(price_reco_detail):
                 price_raw_detail = price_reco_detail.raw_detail
                 price_results = (
                     price_raw_detail.get("filtered", []) if price_raw_detail else []
@@ -1149,7 +1144,7 @@ class SOSBuyItems(CustomAction):
             {"SOSShoppingItemSelected": {"roi": [box[0] - 150, box[1] - 6, 35, 100]}},
         )
 
-        if not selected_reco or not selected_reco.hit:
+        if not is_hit(selected_reco):
             logger.warning(f"左侧未确认选中物品: {item_name}")
             return False
 
@@ -1165,9 +1160,8 @@ class SOSBuyItems(CustomAction):
             {"OCR": {"recognition": "OCR", "roi": bought_roi}},
         )
 
-        if bought_reco and bought_reco.hit:
-            ocr_result = cast(OCRResult, bought_reco.best_result)
-            button_text = ocr_result.text
+        if is_hit(bought_reco):
+            button_text = ocr_text(bought_reco)
 
             if "已购买" in button_text or "已购" in button_text:
                 logger.info(f"物品已购买: {item_name}")
@@ -1175,7 +1169,7 @@ class SOSBuyItems(CustomAction):
 
         # 检查购买按钮并点击
         buy_button_reco = context.run_recognition("SOSBuyButton", img)
-        if buy_button_reco and buy_button_reco.hit:
+        if is_hit(buy_button_reco):
             # 最多重试5次购买
             buy_retry = 0
             while buy_retry < 3:
@@ -1194,9 +1188,8 @@ class SOSBuyItems(CustomAction):
                     {"OCR": {"recognition": "OCR", "roi": bought_roi}},
                 )
 
-                if confirm_reco and confirm_reco.hit:
-                    ocr_result = cast(OCRResult, confirm_reco.best_result)
-                    confirm_text = ocr_result.text
+                if is_hit(confirm_reco):
+                    confirm_text = ocr_text(confirm_reco)
 
                     if "已购买" in confirm_text or "已购" in confirm_text:
                         return True
@@ -1227,7 +1220,7 @@ class SOSBuyItems(CustomAction):
             # 检查每个可能的弹窗
             for interrupt in interrupts:
                 rec = context.run_recognition(interrupt, img)
-                if rec and rec.hit:
+                if is_hit(rec):
                     logger.debug(f"检测到弹窗，执行节点: {interrupt}")
                     context.run_task(interrupt)
                     # 执行后重新开始检测，可能有连续弹窗
@@ -1280,9 +1273,8 @@ class SOSSelectNoise(CustomAction):
                 }
             },
         )
-        if reco_detail and reco_detail.hit:
-            ocr_result = cast(OCRResult, reco_detail.best_result)
-            current_level_text = ocr_result.text
+        if is_hit(reco_detail):
+            current_level_text = ocr_text(reco_detail)
             if "颤动" in current_level_text:
                 page = 1
             elif "嗡鸣" in current_level_text:
@@ -1352,9 +1344,8 @@ class SOSSelectNoise(CustomAction):
                     }
                 },
             )
-            if reco_detail and reco_detail.hit:
-                ocr_result = cast(OCRResult, reco_detail.best_result)
-                current_level_text = ocr_result.text
+            if is_hit(reco_detail):
+                current_level_text = ocr_text(reco_detail)
                 if "颤动" in current_level_text:
                     page = 1
                 elif "嗡鸣" in current_level_text:
@@ -1455,12 +1446,11 @@ class SOSSwitchStat(CustomAction):
                 img,
                 {"OCR": {"recognition": "OCR", "roi": roi, "expected": r"\d"}},
             )
-            if not reco_detail or not reco_detail.hit:
+            if not is_hit(reco_detail):
                 logger.warning(f"无法识别属性数值: {stat_names[i]}")
                 results.append(13)
                 continue
-            ocr_result = cast(OCRResult, reco_detail.best_result)
-            results.append(int(ocr_result.text))
+            results.append(int(ocr_text(reco_detail)))
 
         # 选择数值最小的属性
         target_stat = stat_names[results.index(min(results))]

--- a/agent/custom/action/wilderness.py
+++ b/agent/custom/action/wilderness.py
@@ -4,6 +4,7 @@ from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_action import CustomAction
 from utils import logger
+from utils.maa_types import is_hit, ocr_text
 
 
 @AgentServer.custom_action("SummonlngSwipe")
@@ -23,18 +24,13 @@ class SummonlngSwipe(CustomAction):
         reco_first = context.run_recognition("SummonlngCardFirst", img)
         reco_last = context.run_recognition("SummonlngCardLast", img)
 
-        if (
-            reco_first is None
-            or not reco_first.hit
-            or reco_last is None
-            or not reco_last.hit
-        ):
+        if not is_hit(reco_first) or not is_hit(reco_last):
             return CustomAction.RunResult(success=True)
         x1, y1, x2, y2 = (
-            int(reco_first.best_result.box[0] + reco_first.best_result.box[2] / 2),
-            int(reco_first.best_result.box[1] + reco_first.best_result.box[3] / 2),
-            int(reco_last.best_result.box[0] + reco_last.best_result.box[2] / 2),
-            int(reco_last.best_result.box[1] + reco_last.best_result.box[3] / 2),
+            int(reco_first.box[0] + reco_first.box[2] / 2),
+            int(reco_first.box[1] + reco_first.box[3] / 2),
+            int(reco_last.box[0] + reco_last.box[2] / 2),
+            int(reco_last.box[1] + reco_last.box[3] / 2),
         )
         context.tasker.controller.post_swipe(x1, y1, x2, y2, duration=1000).wait()
 
@@ -57,7 +53,7 @@ class GoodDreamWellFishing(CustomAction):
 
         reco_detail = context.run_recognition("GoodDreamWellOCR", img)
 
-        cans = int(reco_detail.best_result.text.split("/")[0])
+        cans = int(ocr_text(reco_detail).split("/")[0])
 
         reco_detail = context.run_recognition(
             "GoodDreamWellOCR",
@@ -71,7 +67,7 @@ class GoodDreamWellFishing(CustomAction):
             },
         )
 
-        hours = int(reco_detail.best_result.text)
+        hours = int(ocr_text(reco_detail))
 
         if hours >= 16 and cans >= 4:
             index = 3

--- a/agent/custom/reco/activity.py
+++ b/agent/custom/reco/activity.py
@@ -6,6 +6,7 @@ from maa.context import Context
 from maa.custom_recognition import CustomRecognition
 from maa.define import RectType
 from utils.logger import logger
+from utils.maa_types import is_hit, ocr_results, ocr_text
 from utils.params import parse_params
 
 
@@ -31,10 +32,7 @@ class ActivityRe_releaseChapter(CustomRecognition):
         ]
         reco_detail = context.run_recognition("ActivityLeftList", argv.image)
 
-        if reco_detail is None or not reco_detail.hit:
-            return CustomRecognition.AnalyzeResult(box=None, detail={})
-
-        for result in reco_detail.all_results:
+        for result in ocr_results(reco_detail):
             if expected in result.text:
                 return CustomRecognition.AnalyzeResult(box=result.box, detail={})
 
@@ -113,6 +111,10 @@ class FindFirstUnplayedStageByCheckmark(CustomRecognition):
         mode = params.get("mode")
         # logger.info(f"[Checkmark] 开始检查关卡，难度: {difficulty}, 模式: {mode}")
 
+        if not isinstance(difficulty, str):
+            logger.error(f"[Checkmark] 无效难度: '{difficulty}'。")
+            return None
+
         stages = self.get_stage_list(difficulty)
         if not stages:
             logger.error(f"[Checkmark] 无效难度: '{difficulty}'。")
@@ -142,7 +144,7 @@ class FindFirstUnplayedStageByCheckmark(CustomRecognition):
                 pipeline_override={checkmark_node_name: {"roi": roi}},
             )
 
-            if result and result.hit:
+            if is_hit(result):
                 # 找到“√”，说明已通关
                 logger.info(f"[Checkmark] '{sid}' 已通关。")
                 if mode == "Quickly":
@@ -185,7 +187,7 @@ class SailingRecordSelectTarget(CustomRecognition):
             reco_detail = context.run_recognition(
                 "SailingRecordFindDifficult", argv.image
             )
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 # 扩展 roi 到 click_target
                 box = [
                     reco_detail.box[0] - 317,
@@ -199,7 +201,7 @@ class SailingRecordSelectTarget(CustomRecognition):
                     argv.image,
                     {"SailingRecordFindNormal": {"roi": box, "only_rec": False}},
                 )
-                text = reco_detail.best_result.text
+                text = ocr_text(reco_detail)
                 # 提取数字，支持负数
                 match = re.search(r"(-?\d+)\s*~\s*(-?\d+)", text)
                 if match:
@@ -218,14 +220,14 @@ class SailingRecordSelectTarget(CustomRecognition):
                     argv.image,
                     {"SailingRecordFindNormal": {"roi": roi}},
                 )
-                if reco_detail is None or not reco_detail.hit:
+                if not is_hit(reco_detail):
                     return CustomRecognition.AnalyzeResult(box=None, detail={})
                 reco_details.append(reco_detail)
 
             diffs, nums = [], []
             for detail in reco_details:
                 # text: 所需点数20~25 或 所需点数-3~3 (含负数)
-                text = detail.best_result.text
+                text = ocr_text(detail)
                 # 提取数字，支持负数
                 match = re.search(r"(-?\d+)\s*~\s*(-?\d+)", text)
                 if match:
@@ -259,17 +261,17 @@ class SailingRecordBoatRecord(CustomRecognition):
 
         roi = [131, 476, 24, 19]
         dices = []
-        for i in range(3):
+        for _i in range(3):
             points = []
-            for j in range(6):
+            for _j in range(6):
                 reco_detail = context.run_recognition(
                     "SailingRecordBoatPointRecord",
                     argv.image,
                     {"SailingRecordBoatPointRecord": {"roi": roi}},
                 )
-                if reco_detail is None or not reco_detail.hit:
+                if not is_hit(reco_detail):
                     return CustomRecognition.AnalyzeResult(box=None, detail={})
-                point = reco_detail.best_result.text
+                point = ocr_text(reco_detail)
                 point = 0 if point in ["?", "？"] else point
                 points.append(int(point))
                 roi = [roi[0] + 47, roi[1], roi[2], roi[3]]

--- a/agent/custom/reco/bank.py
+++ b/agent/custom/reco/bank.py
@@ -3,6 +3,7 @@ from maa.context import Context
 from maa.custom_recognition import CustomRecognition
 from maa.define import RectType
 from utils import logger
+from utils.maa_types import is_hit
 from utils.params import parse_params
 
 
@@ -52,7 +53,7 @@ class BankShop(CustomRecognition):
                     {"BankShopTemplate": {"roi": roi, "expected": expected}},
                 )
 
-                if reco_detail and reco_detail.hit:
+                if is_hit(reco_detail):
                     if inverse:
                         return None
                     return reco_detail.box

--- a/agent/custom/reco/combat.py
+++ b/agent/custom/reco/combat.py
@@ -6,6 +6,7 @@ from maa.context import Context
 from maa.custom_recognition import CustomRecognition
 from maa.define import RectType
 from utils import logger
+from utils.maa_types import is_hit, ocr_text
 
 
 def parse_valid_period_to_hours(text: str) -> float:
@@ -79,13 +80,13 @@ class StagePromotionComplete(CustomRecognition):
         reco_detail2 = context.run_recognition(
             "StagePromotionCurStageComplete2", argv.image
         )
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             if reco_detail.best_result:
                 cur_flag = True
-        if reco_detail1 and reco_detail1.hit:
+        if is_hit(reco_detail1):
             if reco_detail1.best_result:
                 cur_flag = True
-        if reco_detail2 and reco_detail2.hit:
+        if is_hit(reco_detail2):
             if reco_detail2.best_result:
                 cur_flag = True
 
@@ -93,7 +94,7 @@ class StagePromotionComplete(CustomRecognition):
             reco_detail = context.run_recognition(
                 "StagePromotionClickNextStage", argv.image
             )
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 if not reco_detail.best_result:
                     return [0, 0, 0, 0]
             else:
@@ -172,7 +173,7 @@ class CandyPageRecord(CustomRecognition):
 
         # 先确认在吃糖界面
         reco_detail = context.run_recognition("EatCandyPage", argv.image)
-        if not reco_detail or not reco_detail.hit:
+        if not is_hit(reco_detail):
             return None
 
         # 获取当前体力及上限（默认值：体力0，上限240）
@@ -182,22 +183,16 @@ class CandyPageRecord(CustomRecognition):
         reco_remaining = context.run_recognition(
             "CandyRecognizeRemainingAp", argv.image
         )
-        if reco_remaining and reco_remaining.hit:
-            best = getattr(reco_remaining, "best_result", None)
-            if best:
-                text = getattr(best, "text", "")
-                digits = "".join(ch for ch in (text or "") if ch.isdigit())
-                if digits:
-                    remaining_ap = int(digits)
+        if is_hit(reco_remaining):
+            digits = "".join(ch for ch in ocr_text(reco_remaining) if ch.isdigit())
+            if digits:
+                remaining_ap = int(digits)
 
         reco_max = context.run_recognition("CandyRecognizeMaxAp", argv.image)
-        if reco_max and reco_max.hit:
-            best = getattr(reco_max, "best_result", None)
-            if best:
-                text = getattr(best, "text", "")
-                digits = "".join(ch for ch in (text or "") if ch.isdigit())
-                if digits:
-                    max_ap = int(digits)
+        if is_hit(reco_max):
+            digits = "".join(ch for ch in ocr_text(reco_max) if ch.isdigit())
+            if digits:
+                max_ap = int(digits)
 
         recorded_candies: dict[str, dict[str, Any]] = {
             name: {"index": idx} for idx, name in enumerate(self.candy_names)
@@ -214,12 +209,8 @@ class CandyPageRecord(CustomRecognition):
             )
 
             count = 0
-            best_result = (
-                getattr(reco_detail, "best_result", None) if reco_detail else None
-            )
-            if reco_detail and reco_detail.hit and best_result:
-                text_attr = getattr(best_result, "text", "")
-                raw_text = (text_attr or "").strip()
+            if is_hit(reco_detail):
+                raw_text = ocr_text(reco_detail).strip()
                 digits = "".join(ch for ch in raw_text if ch.isdigit())
                 if digits:
                     count = int(digits)
@@ -232,13 +223,9 @@ class CandyPageRecord(CustomRecognition):
                 argv.image,
                 {"EatCandyPageValidPeriodRecord": {"roi": self.valid_period_rois[idx]}},
             )
-            best_result = (
-                getattr(reco_detail1, "best_result", None) if reco_detail1 else None
-            )
             valid_period_text = ""
-            if reco_detail1 and reco_detail1.hit and best_result:
-                text_attr = getattr(best_result, "text", "")
-                valid_period_text = (text_attr or "").strip()
+            if is_hit(reco_detail1):
+                valid_period_text = ocr_text(reco_detail1).strip()
 
             recorded_candies[candy_name]["valid_period_text"] = valid_period_text
             recorded_candies[candy_name]["valid_period_hours"] = (

--- a/agent/custom/reco/critter_crash.py
+++ b/agent/custom/reco/critter_crash.py
@@ -5,6 +5,7 @@ from maa.context import Context
 from maa.custom_recognition import CustomRecognition
 from maa.define import RectType
 from utils import logger
+from utils.maa_types import is_hit, ocr_text
 from utils.params import parse_params
 
 
@@ -24,7 +25,7 @@ class CCBuyCardRec(CustomRecognition):
 
         # 检查奖励框是否为空
         reco_detail = context.run_recognition("CCBuyCardAwardEmptyRec", argv.image)
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             # 识别到奖励框不为空
             for chess_info in CCChessboard.chess_types:
                 card_name = chess_info["name"]
@@ -37,7 +38,7 @@ class CCBuyCardRec(CustomRecognition):
                         }
                     },
                 )
-                if reco_detail1 and reco_detail1.hit:
+                if is_hit(reco_detail1):
                     # 识别到目标卡片，查询是否可部署/能升级的棋子，有则进行
                     if CCChessboard.find_empty_position(card_name):
                         detail = {"type": 1, "action": 0, "name": card_name}
@@ -59,7 +60,7 @@ class CCBuyCardRec(CustomRecognition):
             reco_detail = context.run_recognition(
                 "CCBuyCardAwardTypeRec_Template", context.tasker.controller.cached_image
             )
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 # 识别到模板，判断不是藏品
                 name = "unknown_2"
             else:
@@ -75,7 +76,7 @@ class CCBuyCardRec(CustomRecognition):
         else:
             # 奖励框为空，检查剩余缪斯币是否足够购买
             reco_detail = context.run_recognition("CCRemainMoney", argv.image)
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 # 钱够了
                 pass
             else:
@@ -96,7 +97,7 @@ class CCBuyCardRec(CustomRecognition):
                         }
                     },
                 )
-                if reco_detail and reco_detail.hit:
+                if is_hit(reco_detail):
                     # 识别成功，检查是否有空位
                     if CCChessboard.find_empty_position(card_name):
                         # 有空位，直接返回
@@ -159,9 +160,10 @@ class CCRemainMoney(CustomRecognition):
                 "CCRemainMoney_rec_refresh", processed_img
             )
 
-        if reco_detail and reco_detail.hit:
-            logger.debug(f"识别到剩余缪斯币: {reco_detail.best_result.text}")
-            if int(reco_detail.best_result.text) >= 3:
+        if is_hit(reco_detail):
+            money = ocr_text(reco_detail)
+            logger.debug(f"识别到剩余缪斯币: {money}")
+            if int(money) >= 3:
                 return CustomRecognition.AnalyzeResult(
                     box=reco_detail.box, detail=reco_detail.raw_detail
                 )

--- a/agent/custom/reco/general.py
+++ b/agent/custom/reco/general.py
@@ -7,6 +7,7 @@ from maa.context import Context
 from maa.custom_recognition import CustomRecognition
 from maa.define import RectType
 from utils.logger import logger
+from utils.maa_types import is_hit, ocr_text
 from utils.params import parse_params
 
 
@@ -86,7 +87,7 @@ class MultiRecognition(CustomRecognition):
 
                 reco_detail = context.run_recognition(node_name, argv.image)
 
-                if reco_detail and reco_detail.hit:
+                if is_hit(reco_detail):
                     # 标准化ROI，将[0,0,0,0]转换为实际全屏坐标，其它不变
                     normalized_roi = self._normalize_roi(list(reco_detail.box))
                     node_results[index_key] = normalized_roi
@@ -132,25 +133,27 @@ class MultiRecognition(CustomRecognition):
         if not uncached_nodes:
             return  # 所有节点都已缓存
 
-        task_id = self._argv.task_detail.task_id
-        task_detail = self._context.tasker.get_task_detail(task_id)
+        argv = self._argv
+        context = self._context
+        if argv is None or context is None:
+            return
+
+        task_id = argv.task_detail.task_id
+        task_detail = context.tasker.get_task_detail(task_id)
 
         if task_detail and task_detail.nodes:
             for node_detail in reversed(task_detail.nodes):
                 if node_detail.name in uncached_nodes:
                     # 缓存识别结果
-                    recognition_success = (
-                        node_detail.recognition is not None
-                        and node_detail.recognition.box is not None
-                    )
+                    recognition = node_detail.recognition
+                    box = recognition.box if recognition is not None else None
+                    recognition_success = box is not None
                     self._external_node_cache[node_detail.name] = recognition_success
 
                     # 缓存ROI
-                    if recognition_success:
+                    if box is not None:
                         # 标准化外部节点的ROI
-                        external_roi = self._normalize_roi(
-                            list(node_detail.recognition.box)
-                        )
+                        external_roi = self._normalize_roi(list(box))
                         self._external_roi_cache[node_detail.name] = external_roi
                     else:
                         self._external_roi_cache[node_detail.name] = None
@@ -172,13 +175,13 @@ class MultiRecognition(CustomRecognition):
         logic_type = logic.get("type", "AND")
 
         if logic_type == "AND":
-            for key, result in node_results.items():
+            for _key, result in node_results.items():
                 if result is None:
                     return False
             return True
 
         elif logic_type == "OR":
-            for key, result in node_results.items():
+            for _key, result in node_results.items():
                 if result is not None:
                     return True
             return False
@@ -213,10 +216,13 @@ class MultiRecognition(CustomRecognition):
                 if external_node_names:
                     # 确保外部节点信息已缓存
                     self._ensure_external_nodes_cached(external_node_names)
+                    external_node_cache = self._external_node_cache
+                    if external_node_cache is None:
+                        return False
 
                     # 替换外部节点引用
                     for node_name in external_node_names:
-                        recognition_success = self._external_node_cache.get(
+                        recognition_success = external_node_cache.get(
                             node_name, False
                         )
                         bool_value = "True" if recognition_success else "False"
@@ -334,10 +340,13 @@ class MultiRecognition(CustomRecognition):
         if external_node_names:
             # 确保外部节点信息已缓存
             self._ensure_external_nodes_cached(external_node_names)
+            external_roi_cache = self._external_roi_cache
+            if external_roi_cache is None:
+                return None
 
             # 替换外部节点ROI引用
             for node_name in external_node_names:
-                roi = self._external_roi_cache.get(node_name)
+                roi = external_roi_cache.get(node_name)
 
                 if roi is not None:
                     roi_str = f"[{roi[0]},{roi[1]},{roi[2]},{roi[3]}]"
@@ -534,6 +543,9 @@ class MultiRecognition(CustomRecognition):
         图像缩放规则：较短边缩放到720，长边按比例缩放
         """
         if roi == [0, 0, 0, 0]:
+            if self._argv is None:
+                return roi
+
             original_height, original_width = self._argv.image.shape[:2]
 
             if original_width <= original_height:
@@ -633,8 +645,8 @@ class ColorOCR(CustomRecognition):
             # 在处理后的图像上运行OCR识别
             reco_detail = context.run_recognition(recognition_node, processed_img)
 
-            if reco_detail and reco_detail.hit:
-                logger.debug(f"ColorOCR识别成功: {reco_detail.best_result.text}")
+            if is_hit(reco_detail):
+                logger.debug(f"ColorOCR识别成功: {ocr_text(reco_detail)}")
                 return CustomRecognition.AnalyzeResult(
                     box=reco_detail.box, detail=reco_detail.raw_detail
                 )
@@ -708,7 +720,7 @@ class ColorOCRWithFallback(CustomRecognition):
             # 在处理后的图像上运行OCR识别
             reco_detail = context.run_recognition(recognition_node, processed_img)
 
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 logger.debug("ColorOCRWithFallback: ColorOCR识别成功")
                 return CustomRecognition.AnalyzeResult(
                     box=reco_detail.box,
@@ -729,7 +741,7 @@ class ColorOCRWithFallback(CustomRecognition):
                 },
             )
 
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 logger.debug("ColorOCRWithFallback: 纯OCR识别成功")
                 return CustomRecognition.AnalyzeResult(
                     box=reco_detail.box,

--- a/agent/custom/reco/syndrome_of_silence.py
+++ b/agent/custom/reco/syndrome_of_silence.py
@@ -1,10 +1,11 @@
-from typing import Any, cast
+from typing import Any
 
 from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_recognition import CustomRecognition
-from maa.define import OCRResult, RectType
+from maa.define import RectType
 from utils import logger
+from utils.maa_types import best_box, boxed_results, is_hit, ocr_text
 
 
 @AgentServer.custom_recognition("SOSSelectEncounterOptionFindSelected")
@@ -22,11 +23,11 @@ class SOSSelectEncounterOptionFindSelected(CustomRecognition):
         reco_detail = context.run_recognition(
             "SOSSelectEncounterOptionRec_Template", argv.image
         )
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             # 放大镜图标的 roi，扩大一点，方便后面颜色匹配
             Magnifier_rois = [
                 [i.box[0] - 10, i.box[1] - 10, i.box[2] + 20, i.box[3] + 12]
-                for i in reco_detail.filtered_results
+                for i in boxed_results(reco_detail)
             ]
         else:
             return CustomRecognition.AnalyzeResult(box=None, detail={})
@@ -43,7 +44,7 @@ class SOSSelectEncounterOptionFindSelected(CustomRecognition):
                 },
             )
 
-            if selected_detail and selected_detail.hit:
+            if is_hit(selected_detail):
                 return CustomRecognition.AnalyzeResult(box=roi, detail={"roi": roi})
 
         return CustomRecognition.AnalyzeResult(box=None, detail={})
@@ -64,11 +65,11 @@ class SOSSelectEncounterOptionList(CustomRecognition):
         reco_detail = context.run_recognition(
             "SOSSelectEncounterOptionRec_Template", argv.image
         )
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             # 放大镜图标的 roi，扩大一点
             Magnifier_rois = [
                 [i.box[0] - 10, i.box[1] - 10, i.box[2] + 20, i.box[3] + 12]
-                for i in reco_detail.filtered_results
+                for i in boxed_results(reco_detail)
             ]
         else:
             return CustomRecognition.AnalyzeResult(box=None, detail={})
@@ -88,7 +89,7 @@ class SOSSelectEncounterOptionList(CustomRecognition):
             )
 
             status = None
-            if unselected_detail and unselected_detail.hit:
+            if is_hit(unselected_detail):
                 status = 0
             else:
                 # 未选中检测失败，再检测是否已选中
@@ -101,7 +102,7 @@ class SOSSelectEncounterOptionList(CustomRecognition):
                         }
                     },
                 )
-                if selected_detail and selected_detail.hit:
+                if is_hit(selected_detail):
                     status = 1
 
             # 匹配到有效状态后,执行 OCR 识别选项内容
@@ -118,9 +119,8 @@ class SOSSelectEncounterOptionList(CustomRecognition):
                 )
 
                 content = ""
-                if ocr_detail and ocr_detail.hit:
-                    ocr_result = cast(OCRResult, ocr_detail.best_result)
-                    content = ocr_result.text
+                if is_hit(ocr_detail):
+                    content = ocr_text(ocr_detail)
 
                     options.append({"roi": roi, "status": status, "content": content})
                     logger.debug(
@@ -149,11 +149,13 @@ class SOSSelectNode(CustomRecognition):
         forbidden_roi = [0, 140, 348, 284]
 
         reco_detail = context.run_recognition("SOSEntrustrRec", argv.image)
-        if reco_detail and reco_detail.hit:
+        if is_hit(reco_detail):
             reco_detail = context.run_recognition("SOSSelectNode_rec", argv.image)
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 # 获取识别到的节点位置
-                node_box = reco_detail.best_result.box
+                node_box = best_box(reco_detail)
+                if node_box is None:
+                    return CustomRecognition.AnalyzeResult(box=None, detail={})
 
                 # 判断是否在禁止区域内
                 x, y, w, h = node_box
@@ -192,9 +194,11 @@ class SOSSelectNode(CustomRecognition):
                     )
         else:
             reco_detail = context.run_recognition("SOSSelectNode_rec", argv.image)
-            if reco_detail and reco_detail.hit:
+            if is_hit(reco_detail):
                 # 获取识别到的节点位置
-                node_box = reco_detail.best_result.box
+                node_box = best_box(reco_detail)
+                if node_box is None:
+                    return CustomRecognition.AnalyzeResult(box=None, detail={})
                 # 不在禁止区域内，返回节点位置供点击
                 return CustomRecognition.AnalyzeResult(
                     box=node_box, detail=reco_detail.raw_detail

--- a/agent/utils/maa_types.py
+++ b/agent/utils/maa_types.py
@@ -1,0 +1,236 @@
+from typing import TypeGuard
+
+from maa.define import (
+    BoxAndCountResult,
+    BoxAndScoreResult,
+    CustomRecognitionResult,
+    OCRResult,
+    RecognitionDetail,
+    RecognitionResult,
+    Rect,
+)
+
+
+class HitRecognitionDetail(RecognitionDetail):
+    """Recognition detail known to be a hit with a concrete box."""
+
+    box: Rect
+
+
+def is_hit(detail: RecognitionDetail | None) -> TypeGuard[HitRecognitionDetail]:
+    """Check whether a recognition detail has a hit and a box.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+
+    Returns:
+        True when the detail exists, is a hit, and contains a non-null box.
+    """
+    return detail is not None and detail.hit and detail.box is not None
+
+
+def require_hit(detail: RecognitionDetail | None) -> HitRecognitionDetail:
+    """Return a hit recognition detail or fail fast.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+
+    Returns:
+        The recognition detail narrowed to a hit detail with a concrete box.
+
+    Raises:
+        ValueError: If the detail is absent, missed, or has no box.
+    """
+    if not is_hit(detail):
+        raise ValueError("recognition detail is not hit")
+    return detail
+
+
+def best_result_as[ResultT](
+    detail: RecognitionDetail | None,
+    result_type: type[ResultT],
+) -> ResultT | None:
+    """Return the best result when it matches the requested type.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+        result_type: Expected result class.
+
+    Returns:
+        The best result narrowed to ``result_type``, or None when there is no
+        hit, no best result, or the best result has a different type.
+    """
+    if detail is None or not detail.hit or detail.best_result is None:
+        return None
+
+    result = detail.best_result
+    if isinstance(result, result_type):
+        return result
+    return None
+
+
+def results_as[ResultT](
+    detail: RecognitionDetail | None,
+    result_type: type[ResultT],
+) -> list[ResultT]:
+    """Return filtered recognition results matching the requested type.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+        result_type: Expected result class.
+
+    Returns:
+        Results from ``filtered_results`` narrowed to ``result_type``. Returns
+        an empty list when the detail is absent or missed.
+    """
+    if detail is None or not detail.hit:
+        return []
+    return [
+        result
+        for result in detail.filtered_results
+        if isinstance(result, result_type)
+    ]
+
+
+def all_results_as[ResultT](
+    detail: RecognitionDetail | None,
+    result_type: type[ResultT],
+) -> list[ResultT]:
+    """Return all recognition results matching the requested type.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+        result_type: Expected result class.
+
+    Returns:
+        Results from ``all_results`` narrowed to ``result_type``. Returns an
+        empty list when the detail is absent or missed.
+    """
+    if detail is None or not detail.hit:
+        return []
+    return [
+        result
+        for result in detail.all_results
+        if isinstance(result, result_type)
+    ]
+
+
+def ocr_result(detail: RecognitionDetail | None) -> OCRResult | None:
+    """Return the best OCR result from a recognition detail.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+
+    Returns:
+        The best OCR result, or None when it is unavailable.
+    """
+    return best_result_as(detail, OCRResult)
+
+
+def require_ocr_result(detail: RecognitionDetail | None) -> OCRResult:
+    """Return the best OCR result or fail fast.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+
+    Returns:
+        The best OCR result.
+
+    Raises:
+        ValueError: If the detail does not contain an OCR result.
+    """
+    result = ocr_result(detail)
+    if result is None:
+        raise ValueError("recognition detail does not contain an OCR result")
+    return result
+
+
+def ocr_text(detail: RecognitionDetail | None, default: str = "") -> str:
+    """Return OCR text from the best result.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+        default: Text returned when no OCR result is available.
+
+    Returns:
+        OCR text from the best result, or ``default``.
+    """
+    result = ocr_result(detail)
+    return result.text if result is not None else default
+
+
+def ocr_results(detail: RecognitionDetail | None) -> list[OCRResult]:
+    """Return all OCR results from a recognition detail.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+
+    Returns:
+        OCR results from ``all_results``. Returns an empty list when the detail
+        is absent or missed.
+    """
+    return all_results_as(detail, OCRResult)
+
+
+def recognition_results(detail: RecognitionDetail | None) -> list[RecognitionResult]:
+    """Return filtered recognition results for a hit detail.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+
+    Returns:
+        ``filtered_results`` when the detail is a hit, otherwise an empty list.
+    """
+    if detail is None or not detail.hit:
+        return []
+    return detail.filtered_results
+
+
+BoxedRecognitionResult = BoxAndScoreResult | BoxAndCountResult | CustomRecognitionResult
+
+
+def has_box_result(result: RecognitionResult | None) -> TypeGuard[BoxedRecognitionResult]:
+    """Check whether a recognition result carries a box.
+
+    Args:
+        result: Recognition result returned by MaaFramework.
+
+    Returns:
+        True when ``result`` is one of the result types with a concrete box.
+    """
+    return isinstance(result, BoxAndScoreResult | BoxAndCountResult | CustomRecognitionResult)
+
+
+def boxed_results(detail: RecognitionDetail | None) -> list[BoxedRecognitionResult]:
+    """Return filtered recognition results that carry boxes.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+
+    Returns:
+        Box-carrying results from ``filtered_results``. Returns an empty list
+        when the detail is absent or missed.
+    """
+    return [
+        result
+        for result in recognition_results(detail)
+        if has_box_result(result)
+    ]
+
+
+def best_box(detail: RecognitionDetail | None) -> Rect | None:
+    """Return the box from the best boxed result.
+
+    Args:
+        detail: Recognition detail returned by MaaFramework.
+
+    Returns:
+        The best result's box, or None when the detail is absent, missed, or
+        the best result does not carry a box.
+    """
+    if detail is None or not detail.hit:
+        return None
+    result = detail.best_result
+    if not has_box_result(result):
+        return None
+    return result.box

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ ignore = [
     "SIM110", # all()/any() (readability preference)
     "SIM117", # nested with (readability preference)
     "SIM118", # key in dict (not always applicable)
-    "B007",   # unused loop variable (common pattern)
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -26,11 +25,6 @@ ignore = [
 pythonVersion = "3.12"
 typeCheckingMode = "basic"
 exclude = [".venv", ".venv-linux", "**/node_modules", "**/__pycache__", ".*", "tmp", "tools", "deps"]
-reportAttributeAccessIssue = "none"
-reportOptionalMemberAccess = "none"
-reportOptionalSubscript = "none"
-reportOptionalCall = "none"
-reportArgumentType = "warning"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -2,6 +2,7 @@ import sys
 import types
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 from agent import agent_runtime
@@ -10,7 +11,7 @@ from agent import agent_runtime
 class AgentRuntimeTest(unittest.TestCase):
     def test_maa_log_dir_matches_pre_refactor_relative_debug_path(self):
         fake_utils = types.ModuleType("utils")
-        fake_logger_module = types.ModuleType("utils.logger")
+        fake_logger_module: Any = types.ModuleType("utils.logger")
         fake_logger_module.change_console_level = Mock()
 
         fake_paths = types.SimpleNamespace(
@@ -18,17 +19,17 @@ class AgentRuntimeTest(unittest.TestCase):
         )
         fake_get_runtime_paths = Mock(return_value=fake_paths)
 
-        fake_agent_server = types.ModuleType("maa.agent.agent_server")
+        fake_agent_server: Any = types.ModuleType("maa.agent.agent_server")
         fake_agent_server.AgentServer = types.SimpleNamespace(
             start_up=Mock(),
             join=Mock(),
             shut_down=Mock(),
         )
 
-        fake_tasker = types.ModuleType("maa.tasker")
+        fake_tasker: Any = types.ModuleType("maa.tasker")
         fake_tasker.Tasker = types.SimpleNamespace(set_log_dir=Mock())
 
-        fake_custom = types.ModuleType("custom")
+        fake_custom: Any = types.ModuleType("custom")
         fake_custom.register_all = Mock()
 
         fake_modules = {

--- a/tests/test_maa_types.py
+++ b/tests/test_maa_types.py
@@ -1,0 +1,155 @@
+import numpy as np
+import pytest
+from maa.define import (
+    BoxAndCountResult,
+    BoxAndScoreResult,
+    CustomRecognitionResult,
+    OCRResult,
+    RecognitionDetail,
+    RecognitionResult,
+    Rect,
+)
+
+from agent.utils.maa_types import (
+    all_results_as,
+    best_box,
+    best_result_as,
+    boxed_results,
+    has_box_result,
+    is_hit,
+    ocr_result,
+    ocr_results,
+    ocr_text,
+    recognition_results,
+    require_hit,
+    require_ocr_result,
+    results_as,
+)
+
+
+def _detail(
+    *,
+    hit: bool,
+    box: Rect | None,
+    all_results: list[RecognitionResult] | None = None,
+    filtered_results: list[RecognitionResult] | None = None,
+    best_result: RecognitionResult | None = None,
+) -> RecognitionDetail:
+    return RecognitionDetail(
+        reco_id=1,
+        name="TestRecognition",
+        algorithm="Test",
+        hit=hit,
+        box=box,
+        all_results=all_results or [],
+        filtered_results=filtered_results or [],
+        best_result=best_result,
+        raw_detail={},
+        raw_image=np.zeros((1, 1, 3), dtype=np.uint8),
+        draw_images=[],
+    )
+
+
+def test_is_hit_requires_detail_hit_and_box() -> None:
+    rect = Rect(1, 2, 3, 4)
+    hit_detail = _detail(hit=True, box=rect)
+
+    assert not is_hit(None)
+    assert not is_hit(_detail(hit=False, box=rect))
+    assert not is_hit(_detail(hit=True, box=None))
+    assert is_hit(hit_detail)
+    assert require_hit(hit_detail) is hit_detail
+
+    with pytest.raises(ValueError, match="recognition detail is not hit"):
+        require_hit(None)
+
+
+def test_typed_result_helpers_filter_best_filtered_and_all_results() -> None:
+    rect = Rect(10, 20, 30, 40)
+    ocr = OCRResult(rect, 0.9, "text")
+    score = BoxAndScoreResult(rect, 0.8)
+    count = BoxAndCountResult(rect, 3)
+    miss = _detail(
+        hit=False,
+        box=rect,
+        all_results=[ocr, score, count],
+        filtered_results=[ocr, score],
+        best_result=ocr,
+    )
+    detail = _detail(
+        hit=True,
+        box=rect,
+        all_results=[ocr, score, count],
+        filtered_results=[ocr, score],
+        best_result=ocr,
+    )
+
+    assert best_result_as(None, OCRResult) is None
+    assert best_result_as(miss, OCRResult) is None
+    assert best_result_as(detail, OCRResult) is ocr
+    assert best_result_as(detail, BoxAndScoreResult) is ocr
+    assert results_as(detail, OCRResult) == [ocr]
+    assert results_as(detail, BoxAndScoreResult) == [ocr, score]
+    assert results_as(miss, OCRResult) == []
+    assert all_results_as(detail, BoxAndCountResult) == [count]
+    assert all_results_as(None, OCRResult) == []
+
+
+def test_ocr_helpers_return_text_and_results() -> None:
+    rect = Rect(1, 1, 2, 2)
+    first = OCRResult(rect, 0.9, "alpha")
+    second = OCRResult(rect, 0.8, "")
+    detail = _detail(
+        hit=True,
+        box=rect,
+        all_results=[first, second],
+        filtered_results=[first],
+        best_result=first,
+    )
+
+    assert ocr_result(detail) is first
+    assert require_ocr_result(detail) is first
+    assert ocr_text(detail) == "alpha"
+    assert ocr_text(None, default="fallback") == "fallback"
+    assert ocr_results(detail) == [first, second]
+
+    no_ocr = _detail(hit=True, box=rect, best_result=BoxAndScoreResult(rect, 0.7))
+    assert ocr_result(no_ocr) is None
+    assert ocr_text(no_ocr) == ""
+    with pytest.raises(ValueError, match="does not contain an OCR result"):
+        require_ocr_result(no_ocr)
+
+
+def test_recognition_and_boxed_helpers_filter_non_hits_and_boxed_result_types() -> None:
+    rect = Rect(4, 5, 6, 7)
+    ocr = OCRResult(rect, 0.9, "text")
+    score = BoxAndScoreResult(rect, 0.8)
+    count = BoxAndCountResult(rect, 2)
+    custom = CustomRecognitionResult(rect, {"kind": "custom"})
+    detail = _detail(
+        hit=True,
+        box=rect,
+        all_results=[ocr, score, count, custom],
+        filtered_results=[ocr, score, count, custom],
+        best_result=score,
+    )
+    miss = _detail(
+        hit=False,
+        box=rect,
+        filtered_results=[score],
+        best_result=score,
+    )
+
+    assert recognition_results(None) == []
+    assert recognition_results(miss) == []
+    assert recognition_results(detail) == [ocr, score, count, custom]
+    assert not has_box_result(None)
+    assert has_box_result(ocr)
+    assert has_box_result(score)
+    assert has_box_result(count)
+    assert has_box_result(custom)
+    assert boxed_results(detail) == [ocr, score, count, custom]
+    assert boxed_results(miss) == []
+    assert best_box(detail) == rect
+    assert best_box(miss) is None
+    assert best_box(_detail(hit=True, box=rect, best_result=ocr)) == rect


### PR DESCRIPTION
## Summary
- add typed Maa recognition helper utilities for hit, OCR, boxed, and typed result access
- migrate custom action/recognition code to use the helpers instead of suppressing pyright issues
- remove Maa-related pyright suppressions and stop ignoring Ruff B007

## Checks
- pnpm lint:py
- pnpm run typecheck
- pnpm test

## Summary by Sourcery

为 Maa 识别结果引入带类型的辅助工具，并重构自定义动作/识别逻辑以使用这些工具，从而实现更安全的 OCR 与命中处理。

Bug Fixes（错误修复）:
- 通过在使用前验证识别难度和棋盘名称，并更健壮地处理缺失的 OCR 文本和框，防止崩溃和异常行为。
- 确保在识别失败或缺少框时，由识别驱动的循环和条件检查依然能正确运行，从而减少自动化流程中的误报/漏报。

Enhancements（功能增强）:
- 新增共享的 Maa 识别辅助模块，提供带类型的命中检测、OCR 文本/结果访问以及带框结果提取等工具函数。
- 重构 combat、syndrome_of_silence、eight_bit、complete_induction、wilderness、activity、reward、bank、lucidscape、record_id、switch_account 以及相关的自定义识别逻辑，使其依赖新的辅助工具，而不是临时的 getattr/cast 模式。
- 加固 general 和 syndrome_of_silence 的识别逻辑，通过安全缓存外部节点数据、防护缺失的 context/argv，并更防御性地规范化 ROI。
- 改进 critter_crash 的棋盘和 bank 逻辑，通过类型校验并使用辅助工具集中处理等级/框解析。

Build（构建）:
- 收紧静态分析要求，在 pyproject.toml 中重新启用 Ruff B007，并移除宽泛的 pyright 可选访问抑制设置。

Tests（测试）:
- 调整 agent 运行时测试，使用带类型的模块 mock，以更好地兼容更严格的类型检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce typed helper utilities for Maa recognition results and refactor custom actions/recognitions to use them for safer OCR and hit handling.

Bug Fixes:
- Prevent crashes and misbehavior by validating recognition difficulty and chess names before use and by handling missing OCR text and boxes more robustly.
- Ensure recognition-driven loops and condition checks behave correctly when recognitions miss or lack boxes, reducing false positives/negatives in automation flows.

Enhancements:
- Add shared Maa recognition helper module providing typed helpers for hit detection, OCR text/result access, and boxed result extraction.
- Refactor combat, syndrome_of_silence, eight_bit, complete_induction, wilderness, activity, reward, bank, lucidscape, record_id, switch_account and related custom recognition logic to rely on the new helpers instead of ad-hoc getattr/cast patterns.
- Harden general and syndrome_of_silence recognition logic by caching external node data safely, guarding against missing context/argv, and normalizing ROIs more defensively.
- Improve critter_crash chessboard and bank logic by validating types and centralizing level/box parsing via helpers.

Build:
- Tighten static analysis by re-enabling Ruff B007 and removing broad pyright optional access suppression settings in pyproject.toml.

Tests:
- Adjust agent runtime tests to use typed module mocks for better compatibility with stricter type checking.

</details>