### PR TITLE
feat: OCR 模型升级到 PP-OCRv6 (small det + tiny rec)

### DIFF
--- a/tools/ci/configure.py
+++ b/tools/ci/configure.py
@@ -14,7 +14,16 @@ def configure_ocr_model():
     shutil.copy2(ocr_root / "small" / "det.onnx", target / "det.onnx")
     shutil.copy2(ocr_root / "tiny" / "rec.onnx", target / "rec.onnx")
     shutil.copy2(ocr_root / "tiny" / "keys.txt", target / "keys.txt")
-    shutil.copy2(ocr_root / "tiny" / "README.md", target / "README.md")
+    # README 准确描述混合组合：det 来自 small 档，rec 来自 tiny 档
+    (target / "README.md").write_text(
+        "# OCR 模型\n\n"
+        "PP-OCRv6 混合组合：\n\n"
+        "- det：PP-OCRv6_small_det（small 档文本检测模型）\n"
+        "- rec：PP-OCRv6_tiny_rec（tiny 档文本识别模型，"
+        "支持简体中文、繁体中文、英文及 46 种拉丁语系语言，不含日文）\n\n"
+        "from <https://www.paddleocr.ai/main/version3.x/algorithm/PP-OCRv6/PP-OCRv6.html>\n",
+        encoding="utf-8",
+    )
 
 
 if __name__ == "__main__":

--- a/tools/ci/configure.py
+++ b/tools/ci/configure.py
@@ -6,11 +6,15 @@ assets_dir = Path(__file__).parent.parent.parent / "assets"
 
 
 def configure_ocr_model():
-    shutil.copytree(
-        assets_dir / "MaaCommonAssets" / "OCR" / "ppocr_v4" / "zh_cn",
-        assets_dir / "resource" / "base" / "model" / "ocr",
-        dirs_exist_ok=True,
-    )
+    # PP-OCRv6 混合组合：det 用 small 档，rec + keys 用 tiny 档
+    ocr_root = assets_dir / "MaaCommonAssets" / "OCR" / "ppocr_v6"
+    target = assets_dir / "resource" / "base" / "model" / "ocr"
+    target.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy2(ocr_root / "small" / "det.onnx", target / "det.onnx")
+    shutil.copy2(ocr_root / "tiny" / "rec.onnx", target / "rec.onnx")
+    shutil.copy2(ocr_root / "tiny" / "keys.txt", target / "keys.txt")
+    shutil.copy2(ocr_root / "tiny" / "README.md", target / "README.md")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🤖 本 PR 由 Claude Code 协助生成。

## 背景

上游 MaaCommonAssets 已新增 PP-OCRv6 模型（[MaaXYZ/MaaCommonAssets#6](https://github.com/MaaXYZ/MaaCommonAssets/pull/6)），官方在 [MaaXYZ/MaaFramework#1370](https://github.com/MaaXYZ/MaaFramework/issues/1370) 给出升级指引。本 PR 将 M9A 的 OCR 模型从 `ppocr_v4` 升级到 `ppocr_v6` 的 **small det + tiny rec** 混合组合。

## 改动

- `tools/ci/configure.py`：由整文件夹 `copytree` 改为逐文件复制——det 取 `ppocr_v6/small`，rec + keys 取 `ppocr_v6/tiny`
- 更新 `MaaCommonAssets` 子模块指针到含 PP-OCRv6 (medium/small/tiny) 的最新提交

## 模型组合

| 文件 | 来源 | 大小 |
|------|------|------|
| det.onnx | ppocr_v6/small | ~9.9 MB |
| rec.onnx | ppocr_v6/tiny | ~4.5 MB |
| keys.txt | ppocr_v6/tiny | ~27 KB |

- det 用 small 档保证文本检测精度
- rec 用 tiny 档减小体积、提升识别速度（v4 rec 10.8 MB → tiny 4.5 MB）
- tiny rec 支持 49 种语言（含中/英，不含日文），M9A 中文场景影响可忽略
- `model/ocr` 被 `.gitignore` 忽略，模型文件不进 git，由 `configure.py` 在本地/CI 生成；`install.py` / `install_cli.py` / `install_mxu.py` 三处 CI 入口均走 `configure_ocr_model()`，改一处即全服生效

## 兼容性

PP-OCRv6 与 v4/v5 同为 PaddleOCR 转 ONNX 的 `det.onnx` / `rec.onnx` / `keys.txt` 三件套，模型格式未变，无需升级 MaaFramework。

## 说明

选用 tiny rec 是在体积/速度与识别精度间的取舍（官方实测建议 small 档）。先合入试用观察一段时间，若发现小字 / 艺术字 / 低对比度文本识别率下降，可随时把 rec 切回 small 档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

将捆绑的 OCR 资源升级为使用 PP-OCRv6 模型，并调整 CI 配置以组装新的“小型检测（small-det）/超小识别（tiny-rec）”混合模型布局。

Enhancements:
- 更改 OCR 模型配置，从复制整个 PP-OCRv4 目录结构，改为分别复制 PP-OCRv6 的检测器/识别器/关键文件。
- 更新 MaaCommonAssets 子模块引用到包含 PP-OCRv6 资源的修订版本。

CI:
- 确保 CI 在准备构建资源时，使用新的 PP-OCRv6 small-det 和 tiny-rec 资源组合来完成 OCR 模型设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the bundled OCR assets to use the PP-OCRv6 model and adjust the CI configuration to assemble the new mixed small-det/tiny-rec model layout.

Enhancements:
- Change OCR model configuration to copy individual PP-OCRv6 detector/recognizer/key files instead of mirroring the previous PP-OCRv4 directory structure.
- Update the MaaCommonAssets submodule reference to a revision that includes PP-OCRv6 assets.

CI:
- Ensure CI OCR model setup uses the new PP-OCRv6 small-det and tiny-rec asset combination when preparing build resources.

</details>