### PR TITLE
chore: 忽略 AGENTS.md（与 CLAUDE.md 一致）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -456,6 +456,7 @@ tools/ImageCropper/**/*.png
 
 # M9A
 CLAUDE.md
+AGENTS.md
 tests/test_auto_promotion_pipeline.py
 python/
 .venv/


### PR DESCRIPTION
🤖 本 PR 由 Claude Code 协助生成。

## 背景

项目 `.gitignore` 已忽略 `CLAUDE.md`（`# M9A` 区块下），但 `AGENTS.md`（内容与 `CLAUDE.md` 完全相同的 AI agent 指令文件副本）未忽略，导致本地 `git status` 一直提示 `?? AGENTS.md`。

## 改动

在 `CLAUDE.md` 忽略规则后新增 `AGENTS.md`，保持一致：

```diff
 # M9A
 CLAUDE.md
+AGENTS.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 由 Sourcery 生成的摘要

构建：
- 更新 `.gitignore`，将 `AGENTS.md` 与 `CLAUDE.md` 一并加入忽略列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update .gitignore to ignore AGENTS.md alongside CLAUDE.md.

</details>