### PR TITLE
fix: narrow warehouse OCR ROI

### DIFF
--- a/assets/resource/base/pipeline/awards.json
+++ b/assets/resource/base/pipeline/awards.json
@@ -378,12 +378,13 @@
             "type": "OCR",
             "param": {
                 "roi": [
-                    4,
-                    154,
-                    149,
-                    397
+                    50,
+                    365,
+                    66,
+                    42
                 ],
-                "expected": "仓库"
+                "expected": "仓库",
+                "only_rec": true
             }
         },
         "action": {

--- a/assets/resource/base/pipeline/balanced_farming.json
+++ b/assets/resource/base/pipeline/balanced_farming.json
@@ -11,12 +11,13 @@
             "type": "OCR",
             "param": {
                 "roi": [
-                    4,
-                    154,
-                    149,
-                    397
+                    50,
+                    365,
+                    66,
+                    42
                 ],
-                "expected": "仓库"
+                "expected": "仓库",
+                "only_rec": true
             }
         },
         "action": {
@@ -89,12 +90,13 @@
             "type": "OCR",
             "param": {
                 "roi": [
-                    4,
-                    154,
-                    149,
-                    397
+                    50,
+                    365,
+                    66,
+                    42
                 ],
-                "expected": "仓库"
+                "expected": "仓库",
+                "only_rec": true
             }
         },
         "next": [


### PR DESCRIPTION
﻿## Summary
- narrow the main-screen warehouse OCR ROI to the warehouse label area
- add `only_rec: true` to the three exact `仓库` OCR checks
- leave `仓库已满` and warehouse page flags unchanged

## Root Cause
The previous ROI scanned the whole left sidebar, so OCR could pick up unrelated entries like mail, tasks, or bank when the warehouse label was partially obscured by the home-screen artwork.

## Validation
- `git diff --check upstream/main...HEAD -- assets/resource/base/pipeline/balanced_farming.json assets/resource/base/pipeline/awards.json`
- `python -m json.tool assets/resource/base/pipeline/balanced_farming.json`
- `node_modules/.bin/prettier.cmd --check assets/resource/base/pipeline/balanced_farming.json assets/resource/base/pipeline/awards.json`
- MaaMCP ADB test on MuMu: temporary OCR-only node with ROI `[50,365,66,42]`, `expected: 仓库`, `only_rec: true` succeeded with score `0.99549`

## Summary by Sourcery

增强：
- 在 awards 和 balanced_farming 流水线中优化仓库 OCR 的 ROI，使其聚焦于仓库标签区域，从而减少误报。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refine warehouse OCR ROI in awards and balanced_farming pipelines to focus on the warehouse label region and reduce false positives.

</details>