### PR TITLE
ci: run pytest in project checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "scripts": {
         "check": "pnpm format:check && pnpm check:schema && pnpm check:maa && pnpm lint",
         "check:maa": "pnpm exec maa-tools check",
-        "check:py": "pnpm lint:py && pnpm typecheck:py",
+        "check:py": "pnpm lint:py && pnpm typecheck:py && pnpm test:py",
         "check:schema": "node tools/validate-schema.mjs",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
@@ -29,6 +29,7 @@
         "release:dry-run": "node tools/build-release.mjs --dry-run",
         "sync:runtime": "node tools/sync-runtime.mjs",
         "sync:schema": "node tools/sync-schema.mjs",
+        "test:py": "uv run --frozen pytest",
         "typecheck:py": "uv run --frozen pyright"
     },
     "type": "module",

--- a/tools/check-project.mjs
+++ b/tools/check-project.mjs
@@ -433,7 +433,8 @@ function expectedPackageScripts(project) {
         scripts["format:py"] = "uv run --frozen ruff format .";
         scripts["lint:py"] = "uv run --frozen ruff check .";
         scripts["typecheck:py"] = "uv run --frozen pyright";
-        scripts["check:py"] = "pnpm lint:py && pnpm typecheck:py";
+        scripts["test:py"] = "uv run --frozen pytest";
+        scripts["check:py"] = "pnpm lint:py && pnpm typecheck:py && pnpm test:py";
     }
     return scripts;
 }


### PR DESCRIPTION
## What changed

- add a dedicated `test:py` package script backed by the locked uv environment
- include it in the existing `check:py` aggregate command used by local and GitHub checks
- update the project contract checker to require the same Python test gate

## Why

M9A already maintains Python regression tests, but the template migration left them outside the required Python aggregate check. This restores the missing test gate without changing the workflow or combining it with slower package smoke tests.

## Validation

- `pnpm test:py` — 21 passed
- `pnpm check:schema`
- `pnpm check:maa`
- `pnpm lint`
- `pnpm check:py`
- Prettier check for the changed files

## Summary by Sourcery

将 Python 测试执行添加到标准项目检查和契约约束中。

新功能：
- 引入专用的 `test:py` 脚本，在锁定的 uv 环境中运行 `pytest`。

改进：
- 在现有的 `check:py` 聚合命令中纳入 Python 测试，该命令用于本地和 CI。
- 更新项目契约检查器，对 Python 项目强制要求 `test:py` 脚本以及扩展后的 `check:py` 闸门。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Python test execution to the standard project checks and contract enforcement.

New Features:
- Introduce a dedicated test:py script that runs pytest in the locked uv environment.

Enhancements:
- Include Python tests in the existing check:py aggregate command used locally and in CI.
- Update the project contract checker to require the test:py script and the expanded check:py gate for Python projects.

</details>