### PR TITLE
fix(updater): make resource updates safe and transactional

### DIFF
--- a/agent/agent_runtime.py
+++ b/agent/agent_runtime.py
@@ -60,6 +60,7 @@ def _hot_update() -> None:
     )
 
     manifest_result = check_manifest_updates()
+    should_save_manifest_cache = manifest_result["success"] and not manifest_result["has_any_update"]
 
     if manifest_result["success"] and not manifest_result["has_any_update"]:
         logger.debug("资源无更新，跳过热更新")
@@ -76,16 +77,19 @@ def _hot_update() -> None:
                 logger.debug("开始检查所有资源...")
 
             update_result = check_and_update_resources(resource_manifests=manifests)
-            if update_result and update_result.get("updated_files"):
-                pass
+            if update_result and update_result.get("success"):
+                should_save_manifest_cache = manifest_result["success"]
             elif update_result and update_result.get("error"):
                 logger.debug(f"热更部分资源更新遇到问题: {update_result['error']}")
             else:
-                logger.debug("热更部分资源已是最新")
+                logger.debug("热更部分资源更新未成功")
         else:
             logger.debug("所有 manifest 无更新，跳过热更新")
 
-    save_manifest_cache_from_result(manifest_result)
+    if should_save_manifest_cache:
+        save_manifest_cache_from_result(manifest_result)
+    else:
+        logger.debug("热更新未完整成功，保留原 manifest 缓存")
 
 
 def run_agent(project_root_dir: str) -> int:

--- a/agent/utils/manifest_checker.py
+++ b/agent/utils/manifest_checker.py
@@ -6,6 +6,9 @@ Manifest 缓存检查模块
 """
 
 import json
+import os
+import tempfile
+from pathlib import Path
 from typing import Any
 
 import requests  # pyright: ignore[reportMissingModuleSource]
@@ -24,6 +27,7 @@ session = create_no_proxy_session()
 
 # 忽略的目录（不需要热更新）
 IGNORED_DIRS = {"images"}
+IGNORED_MANIFEST_PREFIXES = ("images/", "resource/data/")
 
 
 def _load_cache() -> dict[str, Any]:
@@ -55,23 +59,38 @@ def _load_cache() -> dict[str, Any]:
         return default
 
 
-def _save_cache(cache: dict[str, Any]):
-    """保存缓存到本地"""
+def _save_cache(cache: dict[str, Any]) -> None:
+    """将缓存原子写入本地，避免中断时留下半截 JSON。"""
     cache_file = get_runtime_paths().manifest_cache_file
+    temp_path: Path | None = None
     try:
         cache_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(cache_file, "w", encoding="utf-8") as f:
-            json.dump(cache, f, indent=2, ensure_ascii=False)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=cache_file.parent,
+            prefix=f".{cache_file.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            json.dump(cache, temp_file, indent=2, ensure_ascii=False)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, cache_file)
     except Exception as e:
         logger.debug(f"保存 manifest 缓存失败: {e}")
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.debug(f"清理 manifest 缓存临时文件失败: {temp_path}: {e}")
 
 
 def _is_ignored_path(manifest_path: str) -> bool:
     """检查 manifest 路径是否在忽略目录下"""
-    for ignored in IGNORED_DIRS:
-        if manifest_path.startswith(f"{ignored}/") or manifest_path == f"{ignored}/manifest.json":
-            return True
-    return False
+    return manifest_path.startswith(IGNORED_MANIFEST_PREFIXES)
 
 
 def _collect_updated_manifests(
@@ -115,15 +134,18 @@ def _collect_updated_manifests(
                 logger.debug(f"manifest 需要更新: {manifest_path} ({local_updated} → {remote_updated})")
 
             # 递归检查子目录
+            children_succeeded = True
             for dir_info in manifest.get("directories", []):
                 sub_manifest = dir_info.get("manifest", "")
                 if sub_manifest:
-                    _collect_updated_manifests(
+                    child_succeeded = _collect_updated_manifests(
                         sub_manifest,
                         local_manifests,
                         collected_manifests,
                         updated_manifests,
                     )
+                    children_succeeded = child_succeeded and children_succeeded
+            return children_succeeded
         else:
             logger.debug(f"manifest 无更新: {manifest_path} (updated={remote_updated})")
             # 即使没更新，也要收集子 manifest 的时间戳（用于保存缓存）
@@ -189,6 +211,7 @@ def check_manifest_updates() -> dict[str, Any]:
             return result
 
         # 递归检查各子目录
+        manifests_succeeded = True
         for dir_info in root_manifest.get("directories", []):
             dir_name = dir_info["name"]
             sub_manifest = dir_info.get("manifest", "")
@@ -198,12 +221,19 @@ def check_manifest_updates() -> dict[str, Any]:
                 continue
 
             if sub_manifest:
-                _collect_updated_manifests(
+                manifest_succeeded = _collect_updated_manifests(
                     sub_manifest,
                     local_manifests,
                     result["collected_manifests"],
                     result["updated_manifests"],
                 )
+                manifests_succeeded = manifest_succeeded and manifests_succeeded
+
+        if not manifests_succeeded:
+            result["error"] = "部分 manifest 获取失败"
+            result["has_any_update"] = True
+            logger.debug(result["error"])
+            return result
 
         result["success"] = True
         result["has_any_update"] = len(result["updated_manifests"]) > 0

--- a/agent/utils/resource_updater.py
+++ b/agent/utils/resource_updater.py
@@ -5,8 +5,9 @@
 """
 
 import hashlib
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
+import os
+import tempfile
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import requests  # pyright: ignore[reportMissingModuleSource]
@@ -19,8 +20,17 @@ from .runtime_paths import get_runtime_paths
 DEFAULT_API_BASE_URL = "https://api.1999.fan/api"
 DEFAULT_TIMEOUT = 5  # 缩短超时时间
 
+# 与 manifest_checker 保持一致；图片和迁移前的旧 data 路径不参与热更新。
+IGNORED_MANIFEST_PREFIXES = ("images/", "resource/data/")
+
 # 不使用系统代理（国内服务器直连更快）
 session = create_no_proxy_session()
+
+
+class FileHashMismatchError(ValueError):
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+        super().__init__(f"文件哈希验证失败: {file_path}")
 
 
 def calculate_file_hash(file_path: Path) -> str:
@@ -41,54 +51,121 @@ def calculate_file_hash(file_path: Path) -> str:
     return sha256.hexdigest()
 
 
+def _normalize_relative_path(path_value: Any, *, label: str) -> str:
+    """校验并规范化 manifest 中的 POSIX 相对路径。"""
+    if not isinstance(path_value, str) or not path_value:
+        raise ValueError(f"{label} 不是有效的非空字符串")
+    if "\\" in path_value:
+        raise ValueError(f"{label} 不能包含反斜杠: {path_value}")
+
+    path = PurePosixPath(path_value)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"{label} 必须位于项目目录内: {path_value}")
+    if not path.parts or ":" in path.parts[0]:
+        raise ValueError(f"{label} 不是有效的相对路径: {path_value}")
+    return path.as_posix()
+
+
+def _resolve_project_file(project_root: Path, file_path_value: Any) -> tuple[str, Path]:
+    """将 manifest 文件路径解析到项目根目录内，并拒绝路径逃逸。"""
+    file_path_str = _normalize_relative_path(file_path_value, label="文件路径")
+    root = project_root.resolve()
+    relative_path = Path(*PurePosixPath(file_path_str).parts)
+    file_path = (root / relative_path).resolve(strict=False)
+    if not file_path.is_relative_to(root):
+        raise ValueError(f"文件路径超出项目目录: {file_path_str}")
+    return file_path_str, file_path
+
+
+def _validate_sha256(hash_value: Any, file_path: str) -> str:
+    if not isinstance(hash_value, str) or len(hash_value) != 64:
+        raise ValueError(f"文件 SHA256 无效: {file_path}")
+    try:
+        int(hash_value, 16)
+    except ValueError as error:
+        raise ValueError(f"文件 SHA256 无效: {file_path}") from error
+    return hash_value.lower()
+
+
 def get_all_manifests(api_base_url: str, manifest_path: str, timeout: int) -> list[str]:
     """
-    递归获取所有包含文件的 manifest 路径（并行）
+    从根 manifest 递归获取所有包含文件的 manifest 路径。
 
-    Args:
-        api_base_url: API 基础 URL
-        manifest_path: 当前 manifest 路径（如 "resource/manifest.json"）
-        timeout: 请求超时时间
-
-    Returns:
-        包含文件的 manifest 路径列表
+    任一子 manifest 获取失败都会抛出异常，避免把不完整清单当作成功。
     """
-    manifest_url = f"{api_base_url}/{manifest_path}"
+    collected: list[str] = []
+    visited: set[str] = set()
 
-    try:
+    def collect(current_path_value: Any) -> None:
+        current_path = _normalize_relative_path(current_path_value, label="manifest 路径")
+        if current_path in visited:
+            return
+        visited.add(current_path)
+
+        if current_path.startswith(IGNORED_MANIFEST_PREFIXES):
+            logger.debug(f"跳过忽略的 manifest: {current_path}")
+            return
+
+        manifest_url = f"{api_base_url.rstrip('/')}/{current_path}"
         response = session.get(manifest_url, timeout=timeout)
         response.raise_for_status()
         manifest = response.json()
+        if not isinstance(manifest, dict):
+            raise ValueError(f"manifest 内容不是对象: {current_path}")
 
-        # 如果有 directories，并行递归获取子目录的 manifest
-        if "directories" in manifest and manifest["directories"]:
-            result = []
-            sub_manifest_paths = [d["manifest"] for d in manifest["directories"]]
+        if manifest.get("files"):
+            collected.append(current_path)
 
-            # 使用线程池并行请求
-            with ThreadPoolExecutor(max_workers=5) as executor:
-                futures = {
-                    executor.submit(get_all_manifests, api_base_url, path, timeout): path for path in sub_manifest_paths
-                }
+        for dir_info in manifest.get("directories", []):
+            if not isinstance(dir_info, dict):
+                raise ValueError(f"manifest 子目录无效: {current_path}")
+            collect(dir_info.get("manifest"))
 
-                for future in as_completed(futures):
-                    try:
-                        result.extend(future.result())
-                    except Exception as e:
-                        path = futures[future]
-                        logger.warning(f"获取 {path} 失败: {str(e)}")
+    collect(manifest_path)
+    return collected
 
-            return result
 
-        # 如果有 files，说明这是最终的文件清单，返回该路径
-        if "files" in manifest and manifest["files"]:
-            return [manifest_path]
+def _stage_download(
+    api_base_url: str,
+    file_path_str: str,
+    file_path: Path,
+    remote_hash: str,
+    timeout: int,
+) -> Path:
+    """下载到目标目录旁的临时文件，并在返回前完成哈希校验。"""
+    file_url = f"{api_base_url.rstrip('/')}/{file_path_str}"
+    logger.debug(f"下载文件: {file_url}")
 
-        return []
+    file_response = session.get(file_url, timeout=timeout)
+    file_response.raise_for_status()
+    content = file_response.content
+    downloaded_hash = hashlib.sha256(content).hexdigest()
+    if downloaded_hash != remote_hash:
+        raise FileHashMismatchError(file_path_str)
 
-    except Exception as e:
-        logger.warning(f"获取 {manifest_path} 失败: {str(e)}")
-        return []
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=file_path.parent,
+            prefix=f".{file_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            temp_file.write(content)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        assert temp_path is not None
+        return temp_path
+    except Exception:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError as error:
+                logger.debug(f"清理热更新临时文件失败: {temp_path}: {error}")
+        raise
 
 
 def check_and_update_resources(
@@ -96,124 +173,66 @@ def check_and_update_resources(
     resource_manifests: list[str] | None = None,
     timeout: int = DEFAULT_TIMEOUT,
 ) -> dict[str, Any]:
-    """
-    检查并更新资源文件
-
-    Args:
-        api_base_url: API 基础 URL
-        resource_manifests: 需要更新的 manifest 路径列表，如果为 None 则从 API 递归获取
-        timeout: 请求超时时间（秒）
-
-    Returns:
-        dict: {
-            "success": bool,  # 是否成功
-            "updated_files": List[str],  # 已更新的文件列表
-            "failed_files": List[str],  # 更新失败的文件列表
-            "error": str  # 错误信息
-        }
-    """
+    """检查并以可重试事务更新资源文件。"""
     result: dict[str, Any] = {
         "success": True,
         "updated_files": [],
         "failed_files": [],
         "error": "",
     }
+    staged_files: list[tuple[str, Path, Path]] = []
 
     try:
-        project_root = get_runtime_paths().work_root
+        project_root = get_runtime_paths().work_root.resolve()
 
-        # 如果未指定 manifest 列表，则从 API 递归获取所有
         if resource_manifests is None:
-            try:
-                logger.debug("开始递归获取资源清单列表")
-                resource_manifests = get_all_manifests(api_base_url, "resource/manifest.json", timeout)
-                logger.debug(f"自动获取到 {len(resource_manifests)} 个资源清单")
-
-                if not resource_manifests:
-                    logger.warning("未获取到任何可用的资源清单")
-                    result["error"] = "未获取到可用的资源清单"
-                    result["success"] = False
-                    return result
-
-            except Exception as e:
-                error_msg = f"获取资源清单列表失败: {str(e)}"
-                logger.warning(error_msg)
-                result["error"] = error_msg
-                result["success"] = False
-                return result
+            logger.debug("开始从根 manifest 递归获取资源清单列表")
+            resource_manifests = get_all_manifests(api_base_url, "manifest.json", timeout)
+            logger.debug(f"自动获取到 {len(resource_manifests)} 个资源清单")
+            if not resource_manifests:
+                raise ValueError("未获取到可用的资源清单")
         else:
             logger.debug(f"使用指定的 {len(resource_manifests)} 个资源清单")
 
-        for manifest_path in resource_manifests:
-            try:
-                # 获取远程 manifest
-                manifest_url = f"{api_base_url}/{manifest_path}"
-                logger.debug(f"获取资源清单: {manifest_url}")
+        seen_targets: set[Path] = set()
+        for manifest_path_value in resource_manifests:
+            manifest_path = _normalize_relative_path(manifest_path_value, label="manifest 路径")
+            manifest_url = f"{api_base_url.rstrip('/')}/{manifest_path}"
+            logger.debug(f"获取资源清单: {manifest_url}")
 
-                response = session.get(manifest_url, timeout=timeout)
-                response.raise_for_status()
-                manifest = response.json()
+            response = session.get(manifest_url, timeout=timeout)
+            response.raise_for_status()
+            manifest = response.json()
+            if not isinstance(manifest, dict):
+                raise ValueError(f"manifest 内容不是对象: {manifest_path}")
 
-                # 检查并更新每个文件
-                for file_info in manifest.get("files", []):
-                    file_path_str = file_info["path"]
-                    remote_hash = file_info["hash"]
-                    # 使用 manifest 中的完整路径
-                    file_path = project_root / file_path_str
+            for file_info in manifest.get("files", []):
+                if not isinstance(file_info, dict):
+                    raise ValueError(f"manifest 文件条目无效: {manifest_path}")
 
-                    # 检查本地文件是否需要更新
-                    need_update = False
-                    if not file_path.exists():
-                        logger.debug(f"本地文件不存在: {file_path_str}")
-                        need_update = True
-                    else:
-                        local_hash = calculate_file_hash(file_path)
-                        if local_hash != remote_hash:
-                            logger.debug(f"文件哈希不匹配: {file_path_str}")
-                            logger.debug(f"  本地 hash: {local_hash}")
-                            logger.debug(f"  远程 hash: {remote_hash}")
-                            logger.debug(f"  文件大小: {file_path.stat().st_size} bytes")
-                            need_update = True
+                file_path_str, file_path = _resolve_project_file(project_root, file_info.get("path"))
+                remote_hash = _validate_sha256(file_info.get("hash"), file_path_str)
+                if file_path in seen_targets:
+                    raise ValueError(f"manifest 包含重复文件路径: {file_path_str}")
+                seen_targets.add(file_path)
 
-                    if need_update:
-                        # 下载文件
-                        file_url = f"{api_base_url}/{file_path_str}"
-                        logger.debug(f"下载文件: {file_url}")
+                if file_path.exists() and calculate_file_hash(file_path) == remote_hash:
+                    logger.debug(f"文件已是最新: {file_path_str}")
+                    continue
 
-                        file_response = session.get(file_url, timeout=timeout)
-                        file_response.raise_for_status()
+                temp_path = _stage_download(
+                    api_base_url,
+                    file_path_str,
+                    file_path,
+                    remote_hash,
+                    timeout,
+                )
+                staged_files.append((file_path_str, file_path, temp_path))
 
-                        # 验证下载的文件哈希
-                        downloaded_hash = hashlib.sha256(file_response.content).hexdigest()
-                        if downloaded_hash != remote_hash:
-                            logger.warning(f"文件哈希验证失败: {file_path_str}")
-                            result["failed_files"].append(file_path_str)
-                            continue
-
-                        # 确保目录存在
-                        file_path.parent.mkdir(parents=True, exist_ok=True)
-
-                        # 保存文件
-                        with open(file_path, "wb") as f:
-                            f.write(file_response.content)
-
-                        # logger.info(
-                        #     f"已更新: {file_path_str} ({file_info['size']} bytes)"
-                        # )
-                        result["updated_files"].append(file_path_str)
-                    else:
-                        logger.debug(f"文件已是最新: {file_path_str}")
-
-            except requests.exceptions.RequestException as e:
-                error_msg = f"更新 {manifest_path} 资源失败: 网络错误 - {str(e)}"
-                logger.warning(error_msg)
-                result["error"] = error_msg
-                result["success"] = False
-            except Exception as e:
-                error_msg = f"更新 {manifest_path} 资源失败: {str(e)}"
-                logger.warning(error_msg)
-                result["error"] = error_msg
-                result["success"] = False
+        # 所有下载和哈希校验完成后才替换正式文件。
+        for file_path_str, file_path, temp_path in staged_files:
+            os.replace(temp_path, file_path)
+            result["updated_files"].append(file_path_str)
 
         if result["updated_files"]:
             logger.info(
@@ -222,10 +241,24 @@ def check_and_update_resources(
         else:
             logger.debug("所有资源文件已是最新")
 
-        return result
-
-    except Exception as e:
+    except requests.exceptions.RequestException as error:
         result["success"] = False
-        result["error"] = f"资源更新异常: {str(e)}"
-        logger.exception("资源更新时发生异常")
-        return result
+        result["error"] = f"资源更新网络错误: {error}"
+        logger.warning(result["error"])
+    except FileHashMismatchError as error:
+        result["success"] = False
+        result["failed_files"].append(error.file_path)
+        result["error"] = f"资源更新失败: {error}"
+        logger.warning(result["error"])
+    except Exception as error:
+        result["success"] = False
+        result["error"] = f"资源更新失败: {error}"
+        logger.warning(result["error"])
+    finally:
+        for _, _, temp_path in staged_files:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError as error:
+                logger.debug(f"清理热更新临时文件失败: {temp_path}: {error}")
+
+    return result

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -35,3 +35,61 @@ def test_maa_log_dir_matches_pre_refactor_relative_debug_path() -> None:
                     agent_runtime.run_agent("C:/Users/example/新建文件夹")
 
     fake_tasker.Tasker.set_log_dir.assert_called_once_with("./debug")
+
+
+def test_hot_update_does_not_save_cache_after_failed_update() -> None:
+    save_cache = Mock()
+    check_result = {
+        "success": True,
+        "has_any_update": True,
+        "updated_manifests": ["data/manifest.json"],
+    }
+    fake_manifest_checker: Any = types.ModuleType("utils.manifest_checker")
+    fake_manifest_checker.check_manifest_updates = Mock(return_value=check_result)
+    fake_manifest_checker.save_manifest_cache_from_result = save_cache
+
+    fake_resource_updater: Any = types.ModuleType("utils.resource_updater")
+    fake_resource_updater.check_and_update_resources = Mock(
+        return_value={"success": False, "updated_files": [], "error": "hash mismatch"}
+    )
+
+    with patch.dict(
+        sys.modules,
+        {
+            "utils.manifest_checker": fake_manifest_checker,
+            "utils.resource_updater": fake_resource_updater,
+        },
+    ):
+        with patch.object(agent_runtime, "_read_hot_update_config", return_value={"enable_hot_update": True}):
+            agent_runtime._hot_update()
+
+    save_cache.assert_not_called()
+
+
+def test_hot_update_saves_cache_after_successful_update() -> None:
+    save_cache = Mock()
+    check_result = {
+        "success": True,
+        "has_any_update": True,
+        "updated_manifests": ["data/manifest.json"],
+    }
+    fake_manifest_checker: Any = types.ModuleType("utils.manifest_checker")
+    fake_manifest_checker.check_manifest_updates = Mock(return_value=check_result)
+    fake_manifest_checker.save_manifest_cache_from_result = save_cache
+
+    fake_resource_updater: Any = types.ModuleType("utils.resource_updater")
+    fake_resource_updater.check_and_update_resources = Mock(
+        return_value={"success": True, "updated_files": ["data/value.json"], "error": ""}
+    )
+
+    with patch.dict(
+        sys.modules,
+        {
+            "utils.manifest_checker": fake_manifest_checker,
+            "utils.resource_updater": fake_resource_updater,
+        },
+    ):
+        with patch.object(agent_runtime, "_read_hot_update_config", return_value={"enable_hot_update": True}):
+            agent_runtime._hot_update()
+
+    save_cache.assert_called_once_with(check_result)

--- a/tests/test_manifest_checker.py
+++ b/tests/test_manifest_checker.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+import requests
+
+from agent.utils import manifest_checker
+
+
+class FakeResponse:
+    def __init__(self, json_data: dict[str, Any]) -> None:
+        self._json_data = json_data
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._json_data
+
+
+class FailingChildSession:
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        del timeout
+        if url == manifest_checker.MANIFEST_URL:
+            return FakeResponse(
+                {
+                    "updated": 2,
+                    "directories": [{"name": "data", "manifest": "data/manifest.json"}],
+                }
+            )
+        if url.endswith("/data/manifest.json"):
+            return FakeResponse(
+                {
+                    "updated": 2,
+                    "directories": [{"manifest": "data/activity/manifest.json"}],
+                }
+            )
+        raise requests.ConnectionError("child manifest unavailable")
+
+
+class LegacyManifestSession:
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        del timeout
+        if url == manifest_checker.MANIFEST_URL:
+            return FakeResponse(
+                {
+                    "updated": 2,
+                    "directories": [{"name": "resource", "manifest": "resource/manifest.json"}],
+                }
+            )
+        if url.endswith("/resource/manifest.json"):
+            return FakeResponse(
+                {
+                    "updated": 2,
+                    "directories": [{"manifest": "resource/data/manifest.json"}],
+                }
+            )
+        raise AssertionError(f"legacy manifest should be ignored: {url}")
+
+
+def test_child_manifest_failure_marks_check_as_failed(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        manifest_checker,
+        "_load_cache",
+        lambda: {
+            "root_updated": 1,
+            "manifests": {
+                "manifest.json": 1,
+                "data/manifest.json": 1,
+                "data/activity/manifest.json": 1,
+            },
+        },
+    )
+    monkeypatch.setattr(manifest_checker, "session", FailingChildSession())
+
+    result = manifest_checker.check_manifest_updates()
+
+    assert result["success"] is False
+    assert result["has_any_update"] is True
+    assert result["error"] == "部分 manifest 获取失败"
+
+
+def test_legacy_resource_data_manifest_is_ignored(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        manifest_checker,
+        "_load_cache",
+        lambda: {
+            "root_updated": 1,
+            "manifests": {
+                "manifest.json": 1,
+                "resource/manifest.json": 1,
+            },
+        },
+    )
+    monkeypatch.setattr(manifest_checker, "session", LegacyManifestSession())
+
+    result = manifest_checker.check_manifest_updates()
+
+    assert result["success"] is True
+    assert result["has_any_update"] is False
+    assert result["collected_manifests"]["resource/manifest.json"] == 2

--- a/tests/test_resource_updater.py
+++ b/tests/test_resource_updater.py
@@ -1,0 +1,169 @@
+import hashlib
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent.utils import resource_updater
+
+
+class FakeResponse:
+    def __init__(self, *, json_data: Any = None, content: bytes = b"") -> None:
+        self._json_data = json_data
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self._json_data
+
+
+class FakeSession:
+    def __init__(self, responses: dict[str, FakeResponse]) -> None:
+        self.responses = responses
+
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        del timeout
+        if url not in self.responses:
+            raise AssertionError(f"unexpected request: {url}")
+        return self.responses[url]
+
+
+def sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_full_fallback_starts_from_root_manifest(monkeypatch: Any) -> None:
+    api_base = "https://example.test/api"
+    fake_session = FakeSession(
+        {
+            f"{api_base}/manifest.json": FakeResponse(
+                json_data={
+                    "directories": [
+                        {"manifest": "data/manifest.json"},
+                        {"manifest": "resource/manifest.json"},
+                        {"manifest": "images/manifest.json"},
+                    ]
+                }
+            ),
+            f"{api_base}/data/manifest.json": FakeResponse(
+                json_data={"directories": [{"manifest": "data/activity/manifest.json"}]}
+            ),
+            f"{api_base}/data/activity/manifest.json": FakeResponse(json_data={"files": [{"path": "data/a.json"}]}),
+            f"{api_base}/resource/manifest.json": FakeResponse(
+                json_data={
+                    "directories": [
+                        {"manifest": "resource/base/manifest.json"},
+                        {"manifest": "resource/data/manifest.json"},
+                    ]
+                }
+            ),
+            f"{api_base}/resource/base/manifest.json": FakeResponse(
+                json_data={"files": [{"path": "resource/base/a.json"}]}
+            ),
+        }
+    )
+    monkeypatch.setattr(resource_updater, "session", fake_session)
+
+    manifests = resource_updater.get_all_manifests(api_base, "manifest.json", timeout=5)
+
+    assert manifests == ["data/activity/manifest.json", "resource/base/manifest.json"]
+
+
+@pytest.mark.parametrize("unsafe_path", ["../outside.txt", "/absolute.txt", "C:/outside.txt", "..\\outside.txt"])
+def test_rejects_file_path_outside_work_root(monkeypatch: Any, tmp_path: Any, unsafe_path: str) -> None:
+    api_base = "https://example.test/api"
+    work_root = tmp_path / "project"
+    work_root.mkdir()
+    monkeypatch.setattr(resource_updater, "get_runtime_paths", lambda: SimpleNamespace(work_root=work_root))
+    monkeypatch.setattr(
+        resource_updater,
+        "session",
+        FakeSession(
+            {
+                f"{api_base}/resource/manifest.json": FakeResponse(
+                    json_data={"files": [{"path": unsafe_path, "hash": sha256(b"unsafe")}]}
+                )
+            }
+        ),
+    )
+
+    result = resource_updater.check_and_update_resources(
+        api_base_url=api_base,
+        resource_manifests=["resource/manifest.json"],
+    )
+
+    assert result["success"] is False
+    assert "unexpected request" not in result["error"]
+    assert result["updated_files"] == []
+    assert not (tmp_path / "outside.txt").exists()
+
+
+def test_hash_failure_does_not_commit_other_staged_files(monkeypatch: Any, tmp_path: Any) -> None:
+    api_base = "https://example.test/api"
+    work_root = tmp_path / "project"
+    good_path = work_root / "data" / "good.txt"
+    good_path.parent.mkdir(parents=True)
+    good_path.write_bytes(b"old")
+    good_content = b"new-good"
+    expected_bad_content = b"expected-bad"
+
+    monkeypatch.setattr(resource_updater, "get_runtime_paths", lambda: SimpleNamespace(work_root=work_root))
+    monkeypatch.setattr(
+        resource_updater,
+        "session",
+        FakeSession(
+            {
+                f"{api_base}/data/test/manifest.json": FakeResponse(
+                    json_data={
+                        "files": [
+                            {"path": "data/good.txt", "hash": sha256(good_content)},
+                            {"path": "data/bad.txt", "hash": sha256(expected_bad_content)},
+                        ]
+                    }
+                ),
+                f"{api_base}/data/good.txt": FakeResponse(content=good_content),
+                f"{api_base}/data/bad.txt": FakeResponse(content=b"tampered"),
+            }
+        ),
+    )
+
+    result = resource_updater.check_and_update_resources(
+        api_base_url=api_base,
+        resource_manifests=["data/test/manifest.json"],
+    )
+
+    assert result["success"] is False
+    assert result["failed_files"] == ["data/bad.txt"]
+    assert good_path.read_bytes() == b"old"
+    assert not (work_root / "data" / "bad.txt").exists()
+    assert list((work_root / "data").glob(".*.tmp")) == []
+
+
+def test_commits_files_after_all_downloads_are_verified(monkeypatch: Any, tmp_path: Any) -> None:
+    api_base = "https://example.test/api"
+    work_root = tmp_path / "project"
+    content = b"verified"
+    monkeypatch.setattr(resource_updater, "get_runtime_paths", lambda: SimpleNamespace(work_root=work_root))
+    monkeypatch.setattr(
+        resource_updater,
+        "session",
+        FakeSession(
+            {
+                f"{api_base}/data/test/manifest.json": FakeResponse(
+                    json_data={"files": [{"path": "data/value.txt", "hash": sha256(content)}]}
+                ),
+                f"{api_base}/data/value.txt": FakeResponse(content=content),
+            }
+        ),
+    )
+
+    result = resource_updater.check_and_update_resources(
+        api_base_url=api_base,
+        resource_manifests=["data/test/manifest.json"],
+    )
+
+    assert result["success"] is True
+    assert result["updated_files"] == ["data/value.txt"]
+    assert (work_root / "data" / "value.txt").read_bytes() == content


### PR DESCRIPTION
## What changed

- validate every remote manifest and file path before using it, rejecting absolute paths, traversal, Windows drive paths, and backslashes
- make full fallback discovery start at the root manifest so the migrated top-level `data/` tree is covered
- skip the deprecated `resource/data/` compatibility tree while preserving future non-legacy `resource/` updates
- stage all changed files beside their destinations, verify every SHA256 first, and only then atomically replace final files
- propagate child-manifest failures and advance the manifest cache only after a complete successful update
- write the manifest cache through an atomic temporary file replacement

## Why

The hot updater trusted remote file paths and wrote downloads directly to their final destinations. A malformed manifest could escape the project directory, and a network or hash failure could leave a partial update while the timestamp cache still advanced. The project structure migration also moved active data to top-level `data/`, while the fallback path still started from the legacy resource manifest.

## Impact

The update remains retryable: any discovery, download, or hash failure keeps the previous cache and leaves final files unchanged. No task or pipeline behavior is changed.

## Validation

- `pnpm check:py` — Ruff, Pyright, and 32 pytest tests passed
- `pnpm check:schema`
- `pnpm check:maa`
- `pnpm lint`
- live API manifest discovery returned only the four active top-level `data/` leaf manifests
- live update against a temporary work root downloaded and verified all 10 current data files without creating `resource/data/`

## Summary by Sourcery

加固热资源更新流水线，使清单发现、文件下载和缓存写入变得安全、具备事务性，并且被严格限制在项目目录内。

New Features:
- 引入对清单路径和资源文件位置的严格校验，确保它们始终位于项目树内。
- 为下载的资源文件增加事务化的临时阶段，在原子性提交更新之前进行 SHA256 校验。

Bug Fixes:
- 防止格式错误的清单逃离项目目录，或在下载或哈希校验失败时留下部分更新。
- 确保只有在热更新和子清单发现全部成功后才推进清单缓存，避免出现不一致的缓存状态。

Enhancements:
- 更新清单发现逻辑，从根清单开始，忽略旧版的 image 和 resource/data 清单，并向上传播子清单失败。
- 通过使用临时文件和安全替换，使清单缓存写入具备原子性，避免在中断时产生损坏的缓存。
- 优化热更新行为，使资源更新失败时跳过缓存保存，而成功运行则持久化更新后的清单时间戳。

Tests:
- 添加单元测试，覆盖事务化资源更新、路径校验、哈希失败行为以及基于根的清单发现。
- 添加清单检查相关的单元测试，覆盖子清单失败以及忽略旧版 resource/data 清单的行为。
- 扩展代理运行时测试，以验证基于热更新成功与否的清单缓存持久化规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the hot resource update pipeline so that manifest discovery, file downloads, and cache writes are safe, transactional, and confined to the project directory.

New Features:
- Introduce strict validation of manifest paths and resource file locations to ensure they stay within the project tree.
- Add transactional staging of downloaded resource files with SHA256 verification before atomically committing updates.

Bug Fixes:
- Prevent malformed manifests from escaping the project directory or leaving partial updates when downloads or hash checks fail.
- Ensure manifest cache is only advanced after a fully successful hot update and child manifest discovery, avoiding inconsistent cache state.

Enhancements:
- Update manifest discovery to start from the root manifest, ignore legacy image and resource/data manifests, and propagate child-manifest failures.
- Make manifest cache writes atomic via temporary files and safe replacement to avoid corrupted cache on interruption.
- Refine hot-update behavior so failed resource updates skip cache saves while successful runs persist updated manifest timestamps.

Tests:
- Add unit tests for transactional resource updating, path validation, hash failure behavior, and root-based manifest discovery.
- Add unit tests for manifest checking to cover child manifest failures and ignoring legacy resource/data manifests.
- Extend agent runtime tests to verify manifest cache persistence rules based on hot-update success.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

加固热资源更新流水线，使清单发现、文件下载和缓存写入变得安全、具备事务性，并且被严格限制在项目目录内。

New Features:
- 引入对清单路径和资源文件位置的严格校验，确保它们始终位于项目树内。
- 为下载的资源文件增加事务化的临时阶段，在原子性提交更新之前进行 SHA256 校验。

Bug Fixes:
- 防止格式错误的清单逃离项目目录，或在下载或哈希校验失败时留下部分更新。
- 确保只有在热更新和子清单发现全部成功后才推进清单缓存，避免出现不一致的缓存状态。

Enhancements:
- 更新清单发现逻辑，从根清单开始，忽略旧版的 image 和 resource/data 清单，并向上传播子清单失败。
- 通过使用临时文件和安全替换，使清单缓存写入具备原子性，避免在中断时产生损坏的缓存。
- 优化热更新行为，使资源更新失败时跳过缓存保存，而成功运行则持久化更新后的清单时间戳。

Tests:
- 添加单元测试，覆盖事务化资源更新、路径校验、哈希失败行为以及基于根的清单发现。
- 添加清单检查相关的单元测试，覆盖子清单失败以及忽略旧版 resource/data 清单的行为。
- 扩展代理运行时测试，以验证基于热更新成功与否的清单缓存持久化规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the hot resource update pipeline so that manifest discovery, file downloads, and cache writes are safe, transactional, and confined to the project directory.

New Features:
- Introduce strict validation of manifest paths and resource file locations to ensure they stay within the project tree.
- Add transactional staging of downloaded resource files with SHA256 verification before atomically committing updates.

Bug Fixes:
- Prevent malformed manifests from escaping the project directory or leaving partial updates when downloads or hash checks fail.
- Ensure manifest cache is only advanced after a fully successful hot update and child manifest discovery, avoiding inconsistent cache state.

Enhancements:
- Update manifest discovery to start from the root manifest, ignore legacy image and resource/data manifests, and propagate child-manifest failures.
- Make manifest cache writes atomic via temporary files and safe replacement to avoid corrupted cache on interruption.
- Refine hot-update behavior so failed resource updates skip cache saves while successful runs persist updated manifest timestamps.

Tests:
- Add unit tests for transactional resource updating, path validation, hash failure behavior, and root-based manifest discovery.
- Add unit tests for manifest checking to cover child manifest failures and ignoring legacy resource/data manifests.
- Extend agent runtime tests to verify manifest cache persistence rules based on hot-update success.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

加固热资源更新流水线，使清单发现、文件下载和缓存写入变得安全、具备事务性，并且被严格限制在项目目录内。

New Features:
- 引入对清单路径和资源文件位置的严格校验，确保它们始终位于项目树内。
- 为下载的资源文件增加事务化的临时阶段，在原子性提交更新之前进行 SHA256 校验。

Bug Fixes:
- 防止格式错误的清单逃离项目目录，或在下载或哈希校验失败时留下部分更新。
- 确保只有在热更新和子清单发现全部成功后才推进清单缓存，避免出现不一致的缓存状态。

Enhancements:
- 更新清单发现逻辑，从根清单开始，忽略旧版的 image 和 resource/data 清单，并向上传播子清单失败。
- 通过使用临时文件和安全替换，使清单缓存写入具备原子性，避免在中断时产生损坏的缓存。
- 优化热更新行为，使资源更新失败时跳过缓存保存，而成功运行则持久化更新后的清单时间戳。

Tests:
- 添加单元测试，覆盖事务化资源更新、路径校验、哈希失败行为以及基于根的清单发现。
- 添加清单检查相关的单元测试，覆盖子清单失败以及忽略旧版 resource/data 清单的行为。
- 扩展代理运行时测试，以验证基于热更新成功与否的清单缓存持久化规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the hot resource update pipeline so that manifest discovery, file downloads, and cache writes are safe, transactional, and confined to the project directory.

New Features:
- Introduce strict validation of manifest paths and resource file locations to ensure they stay within the project tree.
- Add transactional staging of downloaded resource files with SHA256 verification before atomically committing updates.

Bug Fixes:
- Prevent malformed manifests from escaping the project directory or leaving partial updates when downloads or hash checks fail.
- Ensure manifest cache is only advanced after a fully successful hot update and child manifest discovery, avoiding inconsistent cache state.

Enhancements:
- Update manifest discovery to start from the root manifest, ignore legacy image and resource/data manifests, and propagate child-manifest failures.
- Make manifest cache writes atomic via temporary files and safe replacement to avoid corrupted cache on interruption.
- Refine hot-update behavior so failed resource updates skip cache saves while successful runs persist updated manifest timestamps.

Tests:
- Add unit tests for transactional resource updating, path validation, hash failure behavior, and root-based manifest discovery.
- Add unit tests for manifest checking to cover child manifest failures and ignoring legacy resource/data manifests.
- Extend agent runtime tests to verify manifest cache persistence rules based on hot-update success.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

加固热资源更新流水线，使清单发现、文件下载和缓存写入变得安全、具备事务性，并且被严格限制在项目目录内。

New Features:
- 引入对清单路径和资源文件位置的严格校验，确保它们始终位于项目树内。
- 为下载的资源文件增加事务化的临时阶段，在原子性提交更新之前进行 SHA256 校验。

Bug Fixes:
- 防止格式错误的清单逃离项目目录，或在下载或哈希校验失败时留下部分更新。
- 确保只有在热更新和子清单发现全部成功后才推进清单缓存，避免出现不一致的缓存状态。

Enhancements:
- 更新清单发现逻辑，从根清单开始，忽略旧版的 image 和 resource/data 清单，并向上传播子清单失败。
- 通过使用临时文件和安全替换，使清单缓存写入具备原子性，避免在中断时产生损坏的缓存。
- 优化热更新行为，使资源更新失败时跳过缓存保存，而成功运行则持久化更新后的清单时间戳。

Tests:
- 添加单元测试，覆盖事务化资源更新、路径校验、哈希失败行为以及基于根的清单发现。
- 添加清单检查相关的单元测试，覆盖子清单失败以及忽略旧版 resource/data 清单的行为。
- 扩展代理运行时测试，以验证基于热更新成功与否的清单缓存持久化规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the hot resource update pipeline so that manifest discovery, file downloads, and cache writes are safe, transactional, and confined to the project directory.

New Features:
- Introduce strict validation of manifest paths and resource file locations to ensure they stay within the project tree.
- Add transactional staging of downloaded resource files with SHA256 verification before atomically committing updates.

Bug Fixes:
- Prevent malformed manifests from escaping the project directory or leaving partial updates when downloads or hash checks fail.
- Ensure manifest cache is only advanced after a fully successful hot update and child manifest discovery, avoiding inconsistent cache state.

Enhancements:
- Update manifest discovery to start from the root manifest, ignore legacy image and resource/data manifests, and propagate child-manifest failures.
- Make manifest cache writes atomic via temporary files and safe replacement to avoid corrupted cache on interruption.
- Refine hot-update behavior so failed resource updates skip cache saves while successful runs persist updated manifest timestamps.

Tests:
- Add unit tests for transactional resource updating, path validation, hash failure behavior, and root-based manifest discovery.
- Add unit tests for manifest checking to cover child manifest failures and ignoring legacy resource/data manifests.
- Extend agent runtime tests to verify manifest cache persistence rules based on hot-update success.

</details>

</details>

</details>