### PR TITLE
fix(release): enforce supported drop-core artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
             runtime_os: win
             runtime_arch: x64
             drop_os: windows
+            drop_core_supported: true
+            drop_core_smoke_import: true
             ext: zip
           - os: windows-11-arm
             artifact_os: win
@@ -27,6 +29,9 @@ jobs:
             runtime_os: win
             runtime_arch: arm64
             drop_os: windows
+            # drop_core v1.3.1 has no Windows ARM64 asset; combat falls back to the non-native path.
+            drop_core_supported: false
+            drop_core_smoke_import: false
             ext: zip
           - os: ubuntu-latest
             artifact_os: linux
@@ -34,6 +39,8 @@ jobs:
             runtime_os: linux
             runtime_arch: x64
             drop_os: linux
+            drop_core_supported: true
+            drop_core_smoke_import: true
             ext: tar.gz
           - os: ubuntu-latest
             artifact_os: linux
@@ -41,6 +48,8 @@ jobs:
             runtime_os: linux
             runtime_arch: arm64
             drop_os: linux
+            drop_core_supported: true
+            drop_core_smoke_import: false
             ext: tar.gz
           - os: macos-15-intel
             artifact_os: macos
@@ -48,6 +57,8 @@ jobs:
             runtime_os: osx
             runtime_arch: x64
             drop_os: darwin
+            drop_core_supported: true
+            drop_core_smoke_import: true
             ext: tar.gz
           - os: macos-latest
             artifact_os: macos
@@ -55,6 +66,8 @@ jobs:
             runtime_os: osx
             runtime_arch: arm64
             drop_os: darwin
+            drop_core_supported: true
+            drop_core_smoke_import: true
             ext: tar.gz
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,16 +98,42 @@ jobs:
           CREATE_MAA_PROJECT_RUNTIME_PLATFORM: ${{ matrix.runtime_os }}-${{ matrix.runtime_arch }}
           GITHUB_TOKEN: ${{ github.token }}
       - name: Download drop_core
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' && matrix.drop_core_supported
         shell: bash
         env:
           PRIVATE_REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
         run: |
-          python tools/ci/download_drop_core.py --os "${{ matrix.drop_os }}" --arch "${{ matrix.runtime_arch }}" || echo "[WARN] drop_core download skipped"
+          args=(--os "${{ matrix.drop_os }}" --arch "${{ matrix.runtime_arch }}")
+          if [[ "${{ matrix.drop_core_smoke_import }}" == "true" ]]; then
+            args+=(--smoke-import)
+          fi
+          python tools/ci/download_drop_core.py "${args[@]}"
+      - name: Note unsupported drop_core target
+        if: github.event_name != 'workflow_dispatch' && matrix.drop_core_supported == false
+        shell: bash
+        run: echo "[INFO] drop_core is not published for ${{ matrix.drop_os }}-${{ matrix.runtime_arch }}"
       - run: node tools/build-release.mjs
         if: github.event_name != 'workflow_dispatch'
         env:
           CREATE_MAA_PROJECT_RUNTIME_PLATFORM: ${{ matrix.runtime_os }}-${{ matrix.runtime_arch }}
+      - name: Verify packaged drop_core
+        if: github.event_name != 'workflow_dispatch' && matrix.drop_core_supported
+        shell: bash
+        run: |
+          shopt -s nullglob
+          package_dirs=(dist/package-*)
+          if (( ${#package_dirs[@]} == 0 )); then
+            echo "[ERR] no release packages were generated for a supported drop_core target"
+            exit 1
+          fi
+          for pkg_dir in "${package_dirs[@]}"; do
+            modules=("$pkg_dir"/agent/libs/drop_core*.pyd "$pkg_dir"/agent/libs/drop_core*.so)
+            if (( ${#modules[@]} != 1 )); then
+              echo "[ERR] expected exactly one drop_core module in $pkg_dir, found ${#modules[@]}"
+              exit 1
+            fi
+            echo "[OK] packaged drop_core: ${modules[0]}"
+          done
       - name: Generate manifest cache
         if: github.event_name != 'workflow_dispatch'
         shell: bash

--- a/tests/test_download_drop_core.py
+++ b/tests/test_download_drop_core.py
@@ -1,0 +1,98 @@
+import hashlib
+import io
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.ci import download_drop_core
+
+
+class FakeHTTPResponse(io.BytesIO):
+    def __enter__(self) -> "FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.close()
+
+
+@pytest.mark.parametrize(
+    ("os_type", "arch", "platform_tag", "module_name"),
+    [
+        ("windows", "x64", "win-x64", "drop_core.cp313-win_amd64.pyd"),
+        ("linux", "arm64", "linux-arm64", "drop_core.cpython-313-aarch64-linux-gnu.so"),
+        ("darwin", "x64", "macos-x86_64", "drop_core.cpython-313-darwin.so"),
+        ("darwin", "arm64", "macos-aarch64", "drop_core.cpython-313-darwin.so"),
+    ],
+)
+def test_target_artifact_and_module_names(
+    os_type: str,
+    arch: str,
+    platform_tag: str,
+    module_name: str,
+) -> None:
+    assert download_drop_core.target_platform(os_type, arch) == (arch, platform_tag)
+    assert download_drop_core.expected_module_name(os_type, arch) == module_name
+
+
+def test_rejects_unsupported_architecture() -> None:
+    with pytest.raises(ValueError, match="Unsupported target architecture"):
+        download_drop_core.target_platform("linux", "riscv64")
+
+
+def test_extract_module_accepts_only_expected_root_file(tmp_path: Path) -> None:
+    module_name = "drop_core.cp313-win_amd64.pyd"
+    archive_path = tmp_path / "drop_core.zip"
+    dest_dir = tmp_path / "libs"
+    dest_dir.mkdir()
+    stale_module = dest_dir / "drop_core.cpython-313-x86_64-linux-gnu.so"
+    stale_module.write_bytes(b"stale")
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr(module_name, b"verified-module")
+
+    module_path = download_drop_core.extract_module(archive_path, dest_dir, module_name)
+
+    assert module_path.read_bytes() == b"verified-module"
+    assert not stale_module.exists()
+
+
+def test_extract_module_rejects_unexpected_archive_contents(tmp_path: Path) -> None:
+    archive_path = tmp_path / "drop_core.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("../drop_core.cp313-win_amd64.pyd", b"unsafe")
+
+    with pytest.raises(RuntimeError, match="Unexpected drop_core archive contents"):
+        download_drop_core.extract_module(
+            archive_path,
+            tmp_path / "libs",
+            "drop_core.cp313-win_amd64.pyd",
+        )
+
+
+def test_download_asset_rejects_sha256_mismatch(monkeypatch: Any, tmp_path: Path) -> None:
+    content = b"downloaded"
+    asset = download_drop_core.ReleaseAsset(
+        name="drop_core.zip",
+        url="https://api.github.test/assets/1",
+        digest=f"sha256:{hashlib.sha256(b'expected').hexdigest()}",
+        size=len(content),
+    )
+    monkeypatch.setattr(
+        download_drop_core.urllib.request,
+        "urlopen",
+        lambda request, timeout: FakeHTTPResponse(content),
+    )
+    dest_path = tmp_path / asset.name
+
+    with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+        download_drop_core.download_asset(asset, dest_path, "token")
+
+    assert not dest_path.exists()
+    assert not (tmp_path / "drop_core.zip.part").exists()
+
+
+def test_main_requires_private_repo_token(monkeypatch: Any) -> None:
+    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
+
+    assert download_drop_core.main(["--os", "windows", "--arch", "x64"]) is False

--- a/tools/ci/download_drop_core.py
+++ b/tools/ci/download_drop_core.py
@@ -1,193 +1,229 @@
-"""
-下载 drop_core 模块
+"""从私有 release 下载并验证目标平台的 drop_core 模块。"""
 
-从私有仓库的 release 下载对应平台的 drop_core 模块
-"""
+from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import os
 import platform
 import shutil
+import subprocess
 import sys
 import urllib.request
 import zipfile
-from typing import Any
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
 
-# 私有仓库信息
-PRIVATE_REPO = "MAA1999/drop-upload-sign"  # 修改为你的私有仓库
-RELEASE_TAG = "v1.3.1"  # 修改为要下载的版本
+PRIVATE_REPO = "MAA1999/drop-upload-sign"
+RELEASE_TAG = "v1.3.1"
+DEST_DIR = Path("agent/libs")
+REQUEST_TIMEOUT = 30
+MAX_MODULE_SIZE = 50 * 1024 * 1024
 
-# 目标目录
-DEST_DIR = os.path.join("agent", "libs")
+ARCH_MAPPING = {
+    "amd64": "x64",
+    "x86_64": "x64",
+    "arm64": "arm64",
+    "aarch64": "arm64",
+}
 
 
-def get_platform_info():
-    """获取当前平台信息"""
+@dataclass(frozen=True)
+class ReleaseAsset:
+    name: str
+    url: str
+    digest: str
+    size: int
+
+
+def normalize_arch(value: str) -> str:
+    normalized = ARCH_MAPPING.get(value.lower(), value.lower())
+    if normalized not in {"x64", "arm64"}:
+        raise ValueError(f"Unsupported target architecture: {value}")
+    return normalized
+
+
+def target_platform(os_type: str, arch: str) -> tuple[str, str]:
+    normalized_os = os_type.lower()
+    normalized_arch = normalize_arch(arch)
+    if normalized_os == "windows":
+        return normalized_arch, f"win-{normalized_arch}"
+    if normalized_os == "darwin":
+        suffix = "x86_64" if normalized_arch == "x64" else "aarch64"
+        return normalized_arch, f"macos-{suffix}"
+    if normalized_os == "linux":
+        return normalized_arch, f"linux-{normalized_arch}"
+    raise ValueError(f"Unsupported target OS: {os_type}")
+
+
+def detect_platform() -> tuple[str, str]:
     os_type = platform.system().lower()
-    os_arch = platform.machine().lower()
-
-    # 标准化架构名称
-    arch_mapping = {
-        "amd64": "x64",
-        "x86_64": "x64",
-        "arm64": "arm64",
-        "aarch64": "arm64",
-    }
-
-    # Windows ARM64 检测
-    if os_type == "windows":
-        processor_id = os.environ.get("PROCESSOR_IDENTIFIER", "")
-        if "ARM" in processor_id.upper():
-            os_arch = "arm64"
-
-    arch = arch_mapping.get(os_arch, os_arch)
-
-    # 平台标签
-    if os_type == "windows":
-        platform_tag = f"win-{arch}"
-    elif os_type == "darwin":
-        platform_tag = f"macos-{'x86_64' if arch == 'x64' else 'aarch64'}"
-    elif os_type == "linux":
-        platform_tag = f"linux-{arch}"
-    else:
-        platform_tag = f"{os_type}-{arch}"
-
-    return os_type, arch, platform_tag
+    machine = platform.machine().lower()
+    if os_type == "windows" and "ARM" in os.environ.get("PROCESSOR_IDENTIFIER", "").upper():
+        machine = "arm64"
+    return os_type, normalize_arch(machine)
 
 
-def get_asset_download_url(repo: Any, tag: Any, asset_name: Any, token: Any = None):
-    """Get asset download URL from GitHub API"""
-    api_url = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
-
-    request = urllib.request.Request(api_url)
-    if token:
-        request.add_header("Authorization", f"token {token}")
-    request.add_header("Accept", "application/vnd.github.v3+json")
-
-    try:
-        with urllib.request.urlopen(request) as response:
-            import json
-
-            data = json.loads(response.read().decode())
-
-            # Find the asset by name
-            for asset in data.get("assets", []):
-                if asset["name"] == asset_name:
-                    return asset["url"]  # API URL, not browser_download_url
-
-            print(f"Asset not found: {asset_name}")
-            return None
-    except Exception as e:
-        print(f"Failed to get asset info: {e}")
-        return None
-
-
-def download_file(url: Any, dest_path: Any, token: Any = None):
-    """Download file"""
-    print(f"Downloading: {url}")
-    print(f"To: {dest_path}")
-
-    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-
+def github_request(url: str, token: str, accept: str) -> urllib.request.Request:
     request = urllib.request.Request(url)
-    if token:
-        request.add_header("Authorization", f"token {token}")
-    request.add_header("Accept", "application/octet-stream")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", accept)
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    return request
+
+
+def get_release_asset(repo: str, tag: str, asset_name: str, token: str) -> ReleaseAsset:
+    api_url = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
+    request = github_request(api_url, token, "application/vnd.github+json")
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+        data = json.loads(response.read().decode("utf-8"))
+
+    for asset in data.get("assets", []):
+        if asset.get("name") != asset_name:
+            continue
+        digest = asset.get("digest")
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            raise RuntimeError(f"Release asset has no SHA256 digest: {asset_name}")
+        url = asset.get("url")
+        size = asset.get("size")
+        if not isinstance(url, str) or not isinstance(size, int) or size <= 0:
+            raise RuntimeError(f"Release asset metadata is invalid: {asset_name}")
+        return ReleaseAsset(name=asset_name, url=url, digest=digest, size=size)
+
+    raise RuntimeError(f"Release asset not found: {asset_name}")
+
+
+def download_asset(asset: ReleaseAsset, dest_path: Path, token: str) -> None:
+    expected_hash = asset.digest.removeprefix("sha256:")
+    temp_path = dest_path.with_suffix(f"{dest_path.suffix}.part")
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    dest_path.unlink(missing_ok=True)
+    temp_path.unlink(missing_ok=True)
+
+    request = github_request(asset.url, token, "application/octet-stream")
+    downloaded_size = 0
+    digest = hashlib.sha256()
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response, open(temp_path, "wb") as output:
+            while chunk := response.read(1024 * 1024):
+                output.write(chunk)
+                digest.update(chunk)
+                downloaded_size += len(chunk)
+
+        if downloaded_size != asset.size:
+            raise RuntimeError(
+                f"Release asset size mismatch for {asset.name}: expected {asset.size}, got {downloaded_size}"
+            )
+        if digest.hexdigest() != expected_hash:
+            raise RuntimeError(f"Release asset SHA256 mismatch: {asset.name}")
+        os.replace(temp_path, dest_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def expected_module_name(os_type: str, arch: str) -> str:
+    normalized_arch = normalize_arch(arch)
+    if os_type == "windows":
+        platform_arch = "win_amd64" if normalized_arch == "x64" else "win_arm64"
+        return f"drop_core.cp313-{platform_arch}.pyd"
+    if os_type == "linux":
+        platform_arch = "x86_64" if normalized_arch == "x64" else "aarch64"
+        return f"drop_core.cpython-313-{platform_arch}-linux-gnu.so"
+    if os_type == "darwin":
+        return "drop_core.cpython-313-darwin.so"
+    raise ValueError(f"Unsupported target OS: {os_type}")
+
+
+def extract_module(archive_path: Path, dest_dir: Path, module_name: str) -> Path:
+    temp_path = dest_dir / f".{module_name}.tmp"
+    target_path = dest_dir / module_name
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    temp_path.unlink(missing_ok=True)
 
     try:
-        with urllib.request.urlopen(request) as response:
-            with open(dest_path, "wb") as f:
-                shutil.copyfileobj(response, f)
-        print("Download complete")
-        return True
-    except urllib.error.HTTPError as e:
-        print(f"HTTP error {e.code}: {e.reason}")
-        return False
-    except Exception as e:
-        print(f"Download failed: {e}")
-        return False
+        with zipfile.ZipFile(archive_path, "r") as archive:
+            files = [member for member in archive.infolist() if not member.is_dir()]
+            if len(files) != 1 or files[0].filename != module_name or "\\" in files[0].filename:
+                names = [member.filename for member in files]
+                raise RuntimeError(f"Unexpected drop_core archive contents: {names}")
+            if files[0].file_size <= 0 or files[0].file_size > MAX_MODULE_SIZE:
+                raise RuntimeError(f"Unexpected drop_core module size: {files[0].file_size}")
+            with archive.open(files[0], "r") as source, open(temp_path, "wb") as output:
+                shutil.copyfileobj(source, output)
+
+        if temp_path.stat().st_size <= 0:
+            raise RuntimeError(f"Extracted drop_core module is empty: {module_name}")
+
+        for pattern in ("drop_core*.pyd", "drop_core*.so"):
+            for existing in dest_dir.glob(pattern):
+                if existing != target_path:
+                    existing.unlink()
+        os.replace(temp_path, target_path)
+        return target_path
+    finally:
+        temp_path.unlink(missing_ok=True)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Download drop_core module")
-    parser.add_argument("--os", help="Target OS (windows, linux, darwin)")
-    parser.add_argument("--arch", help="Target architecture (x64, arm64, aarch64, x86_64)")
-    args = parser.parse_args()
+def smoke_import() -> None:
+    env = os.environ.copy()
+    agent_dir = str(DEST_DIR.parent.resolve())
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [agent_dir, env.get("PYTHONPATH", "")]))
+    subprocess.run(
+        [sys.executable, "-c", "from libs import drop_core; print(drop_core.__file__)"],
+        check=True,
+        env=env,
+    )
 
-    # 获取 token（从环境变量）
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download and verify the target drop_core module")
+    parser.add_argument("--os", choices=("windows", "linux", "darwin"), help="Target OS")
+    parser.add_argument("--arch", help="Target architecture")
+    parser.add_argument("--smoke-import", action="store_true", help="Import the extracted module on this runner")
+    args = parser.parse_args(argv)
+    if bool(args.os) != bool(args.arch):
+        parser.error("--os and --arch must be provided together")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> bool:
+    args = parse_args(argv)
     token = os.environ.get("PRIVATE_REPO_TOKEN")
     if not token:
-        print("Warning: PRIVATE_REPO_TOKEN not set, may not be able to access private repo")
-
-    # 获取平台信息
-    if args.os and args.arch:
-        # Use provided OS and arch from command line
-        os_type = args.os.lower()
-        arch_input = args.arch.lower()
-        # Normalize architecture
-        arch_mapping = {
-            "amd64": "x64",
-            "x86_64": "x64",
-            "arm64": "arm64",
-            "aarch64": "arm64",
-        }
-        arch = arch_mapping.get(arch_input, arch_input)
-        # Build platform tag
-        if os_type == "windows":
-            platform_tag = f"win-{arch}"
-        elif os_type == "darwin":
-            platform_tag = f"macos-{'x86_64' if arch == 'x64' else 'aarch64'}"
-        elif os_type == "linux":
-            platform_tag = f"linux-{arch}"
-        else:
-            platform_tag = f"{os_type}-{arch}"
-    else:
-        # Fallback to auto-detection
-        os_type, arch, platform_tag = get_platform_info()
-
-    print(f"Platform: {os_type}, Arch: {arch}")
-
-    # 构造下载列表
-    artifacts = [f"drop_core-{platform_tag}-py3.13-{RELEASE_TAG}"]
-
-    # 下载所有需要的文件
-    success_count = 0
-    for artifact_name in artifacts:
-        asset_name = f"{artifact_name}.zip"
-        download_url = get_asset_download_url(PRIVATE_REPO, RELEASE_TAG, asset_name, token)
-
-        if not download_url:
-            print(f"Cannot get download URL for: {artifact_name}")
-            continue
-
-        zip_path = os.path.join(DEST_DIR, asset_name)
-
-        if download_file(download_url, zip_path, token):
-            # Extract
-            print(f"Extracting: {artifact_name}")
-            try:
-                with zipfile.ZipFile(zip_path, "r") as zf:
-                    zf.extractall(DEST_DIR)
-                os.remove(zip_path)
-                success_count += 1
-            except Exception as e:
-                print(f"Extract failed: {e}")
-        else:
-            print(f"Download failed: {artifact_name}")
-
-    if success_count == 0:
-        print("No files downloaded successfully, skipping drop_core module")
+        print("PRIVATE_REPO_TOKEN is required", file=sys.stderr)
         return False
 
-    # List installed files
-    print("Installed files:")
-    for f in os.listdir(DEST_DIR):
-        if f.endswith((".pyd", ".so")):
-            print(f"  {f}")
+    if args.os and args.arch:
+        os_type = args.os
+        arch = normalize_arch(args.arch)
+    else:
+        os_type, arch = detect_platform()
 
-    return True
+    try:
+        arch, platform_tag = target_platform(os_type, arch)
+        artifact_name = f"drop_core-{platform_tag}-py3.13-{RELEASE_TAG}.zip"
+        module_name = expected_module_name(os_type, arch)
+        print(f"Target: {os_type}-{arch}")
+        print(f"Asset: {artifact_name}")
+
+        asset = get_release_asset(PRIVATE_REPO, RELEASE_TAG, artifact_name, token)
+        archive_path = DEST_DIR / artifact_name
+        try:
+            download_asset(asset, archive_path, token)
+            module_path = extract_module(archive_path, DEST_DIR, module_name)
+        finally:
+            archive_path.unlink(missing_ok=True)
+
+        if args.smoke_import:
+            smoke_import()
+        print(f"Installed and verified: {module_path}")
+        return True
+    except Exception as error:
+        print(f"drop_core setup failed: {error}", file=sys.stderr)
+        return False
 
 
 if __name__ == "__main__":
-    success = main()
-    sys.exit(0 if success else 1)
+    sys.exit(0 if main() else 1)


### PR DESCRIPTION
## What changed

- declare the real drop_core support and import-smoke matrix for every release target
- treat Windows ARM64 as explicitly unsupported by drop_core v1.3.1 instead of emitting a misleading download warning
- fail supported targets when the private token, release asset, download, digest, archive layout, module ABI name, or import smoke is invalid
- verify GitHub's SHA256 digest and asset size before extraction
- extract only the single expected root extension and reject unexpected or oversized archive contents
- verify that every generated package for a supported target contains exactly one drop_core extension

## Why

The previous workflow swallowed every drop_core download failure with `|| echo`, so a supported release could silently omit native drop recognition. At the same time, v1.3.1 does not publish a Windows ARM64 asset and M9A intentionally falls back when the module is unavailable. The release contract therefore needs an explicit support matrix rather than treating every absence the same way.

## Impact

Five published drop_core targets are now fail-closed. Windows ARM64 packages remain supported by M9A, but explicitly ship without the optional native drop module until an upstream asset exists.

## Validation

- `pnpm check:py` — Ruff, Pyright, and 41 pytest tests passed
- `pnpm lint`
- `pnpm release:dry-run`
- Prettier and actionlint v1.7.12 passed for `release.yml`
- live authenticated download, SHA256 verification, extraction, and import smoke passed for Windows x64
- metadata, digest, exact ABI filename, and extraction checks passed for all five v1.3.1 release assets

## Summary by Sourcery

在发布工作流中，为下载、验证和打包 `drop_core` 工件实施严格的支持矩阵和验证流水线。

New Features:
- 使用 GitHub API 元数据和 SHA256 摘要，添加对 `drop_core` 发布资产的、与平台相关的检测、下载和完整性验证。
- 在 CI 中引入可选的 `drop_core` 轻量导入（smoke-import），以验证在受支持目标上解压后的模块是否可以正确加载。
- 验证面向受支持目标生成的发布包中是否恰好包含一个 `drop_core` 扩展模块。

Bug Fixes:
- 将 Windows ARM64 明确视为不受支持的 `drop_core` v1.3.1 目标，而不是在缺失工件时静默跳过并继续发布。
- 当 `drop_core` 资产的元数据、下载、摘要、归档结构或模块 ABI 名称无效时，令发布失败，而不是忽略错误。

Enhancements:
- 将 `drop_core` 下载脚本重构为结构化、可测试的模块，并加入明确的平台规范化逻辑和归档解压安全防护。

CI:
- 扩展发布矩阵，为每个运行时目标添加明确的 `drop_core` 支持和轻量导入标志，并对受支持平台实施“失败即关闭”（fail-closed）行为。

Tests:
- 添加单元测试，覆盖目标工件/模块命名、架构验证、归档解压安全、SHA256 不匹配处理以及 `drop_core` 下载所需令牌等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a strict support matrix and verification pipeline for downloading, validating, and packaging drop_core artifacts in the release workflow.

New Features:
- Add platform-aware detection, download, and integrity verification of drop_core release assets using GitHub API metadata and SHA256 digests.
- Introduce optional smoke-import of drop_core during CI to verify the extracted module loads correctly on supported targets.
- Verify that generated release packages for supported targets contain exactly one drop_core extension module.

Bug Fixes:
- Treat Windows ARM64 as an explicitly unsupported drop_core v1.3.1 target instead of silently skipping missing artifacts and continuing releases.
- Fail releases when drop_core asset metadata, download, digest, archive layout, or module ABI name is invalid rather than ignoring errors.

Enhancements:
- Refactor the drop_core download script into a structured, testable module with explicit platform normalization and archive extraction safeguards.

CI:
- Extend the release matrix with explicit drop_core support and smoke-import flags per runtime target and enforce fail-closed behavior for supported platforms.

Tests:
- Add unit tests covering target artifact/module naming, architecture validation, archive extraction safety, SHA256 mismatch handling, and token requirements for drop_core downloads.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在发布工作流中，为下载、验证和打包 `drop_core` 工件实施严格的支持矩阵和验证流水线。

New Features:
- 使用 GitHub API 元数据和 SHA256 摘要，添加对 `drop_core` 发布资产的、与平台相关的检测、下载和完整性验证。
- 在 CI 中引入可选的 `drop_core` 轻量导入（smoke-import），以验证在受支持目标上解压后的模块是否可以正确加载。
- 验证面向受支持目标生成的发布包中是否恰好包含一个 `drop_core` 扩展模块。

Bug Fixes:
- 将 Windows ARM64 明确视为不受支持的 `drop_core` v1.3.1 目标，而不是在缺失工件时静默跳过并继续发布。
- 当 `drop_core` 资产的元数据、下载、摘要、归档结构或模块 ABI 名称无效时，令发布失败，而不是忽略错误。

Enhancements:
- 将 `drop_core` 下载脚本重构为结构化、可测试的模块，并加入明确的平台规范化逻辑和归档解压安全防护。

CI:
- 扩展发布矩阵，为每个运行时目标添加明确的 `drop_core` 支持和轻量导入标志，并对受支持平台实施“失败即关闭”（fail-closed）行为。

Tests:
- 添加单元测试，覆盖目标工件/模块命名、架构验证、归档解压安全、SHA256 不匹配处理以及 `drop_core` 下载所需令牌等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a strict support matrix and verification pipeline for downloading, validating, and packaging drop_core artifacts in the release workflow.

New Features:
- Add platform-aware detection, download, and integrity verification of drop_core release assets using GitHub API metadata and SHA256 digests.
- Introduce optional smoke-import of drop_core during CI to verify the extracted module loads correctly on supported targets.
- Verify that generated release packages for supported targets contain exactly one drop_core extension module.

Bug Fixes:
- Treat Windows ARM64 as an explicitly unsupported drop_core v1.3.1 target instead of silently skipping missing artifacts and continuing releases.
- Fail releases when drop_core asset metadata, download, digest, archive layout, or module ABI name is invalid rather than ignoring errors.

Enhancements:
- Refactor the drop_core download script into a structured, testable module with explicit platform normalization and archive extraction safeguards.

CI:
- Extend the release matrix with explicit drop_core support and smoke-import flags per runtime target and enforce fail-closed behavior for supported platforms.

Tests:
- Add unit tests covering target artifact/module naming, architecture validation, archive extraction safety, SHA256 mismatch handling, and token requirements for drop_core downloads.

</details>

</details>