### PR TITLE
ci: add pull request package smoke

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,3 +28,4 @@ jobs:
       - run: pnpm check
       - run: pnpm check:py
         if: hashFiles('pyproject.toml') != ''
+      - run: pnpm release:dry-run

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,99 @@
+name: Package Smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/package-smoke.yml"
+      - ".github/workflows/release.yml"
+      - ".python-version"
+      - "agent/**"
+      - "data/**"
+      - "resource/**"
+      - "tasks/**"
+      - "tools/build-release.mjs"
+      - "tools/sync-runtime.mjs"
+      - "tools/ci/**"
+      - "interface.json"
+      - "maa-project.json"
+      - "requirements.txt"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "MaaCommonAssets"
+      - "logo.ico"
+      - "CONTACT"
+      - "LICENSE"
+      - "README.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-x64:
+    name: Windows x64 package smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v8.3.1
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: node tools/check-project.mjs
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm sync:runtime
+        env:
+          CREATE_MAA_PROJECT_RUNTIME_PLATFORM: win-x64
+          GITHUB_TOKEN: ${{ github.token }}
+      - run: node tools/build-release.mjs --release-tag v0.0.0-package-smoke
+        env:
+          CREATE_MAA_PROJECT_RUNTIME_PLATFORM: win-x64
+      - name: Verify package layout and embedded Python
+        shell: pwsh
+        run: |
+          $expected = @("package-mfaa", "package-mxu")
+          $actual = @(
+            Get-ChildItem -LiteralPath dist -Directory |
+              Where-Object Name -Like "package-*" |
+              ForEach-Object Name |
+              Sort-Object
+          )
+          $difference = Compare-Object -ReferenceObject $expected -DifferenceObject $actual
+          if ($difference) {
+            throw "Expected package directories $($expected -join ', '), got $($actual -join ', ')"
+          }
+
+          foreach ($packageName in $expected) {
+            $packageRoot = (Resolve-Path -LiteralPath (Join-Path dist $packageName)).Path
+            $python = Join-Path $packageRoot "python\python.exe"
+            if (-not (Test-Path -LiteralPath $python -PathType Leaf)) {
+              throw "Embedded Python is missing: $python"
+            }
+
+            Push-Location $packageRoot
+            try {
+              & $python -I -c 'import sys; sys.path.insert(0, "agent"); import loguru, maa, PIL, pytz, requests; import agent_runtime, custom; print("embedded Python imports passed")'
+              if ($LASTEXITCODE -ne 0) {
+                throw "Embedded Python import smoke failed in $packageName"
+              }
+              & $python -I -m compileall -q agent
+              if ($LASTEXITCODE -ne 0) {
+                throw "Agent compile smoke failed in $packageName"
+              }
+            } finally {
+              Pop-Location
+            }
+            Write-Host "[OK] $packageName"
+          }

--- a/tools/build-release.mjs
+++ b/tools/build-release.mjs
@@ -13,6 +13,7 @@
 import {basename, dirname, join} from "node:path";
 
 const dryRun = process.argv.includes("--dry-run");
+const releaseTagOverride = commandLineValue("--release-tag");
 const projectSlug = "m9a";
 const releaseArtifactName = "M9A";
 mkdirSync("dist", {recursive: true});
@@ -37,7 +38,7 @@ if (!isReleaseVersion(sourceVersion)) {
     throw new Error("interface.json version must be a release tag such as v0.1.0");
 }
 
-const releaseTag = detectReleaseTag();
+const releaseTag = releaseTagOverride ?? detectReleaseTag();
 if (!dryRun && !releaseTag) {
     throw new Error("release build requires a SemVer Git tag such as v0.1.0");
 }
@@ -645,6 +646,16 @@ function detectReleaseTag() {
     if (typeof refName === "string" && refName.startsWith("v")) return refName;
     const ref = process.env.GITHUB_REF;
     return typeof ref === "string" && ref.startsWith("refs/tags/") ? ref.slice("refs/tags/".length) : undefined;
+}
+
+function commandLineValue(name) {
+    const index = process.argv.indexOf(name);
+    if (index < 0) return undefined;
+    const value = process.argv[index + 1];
+    if (typeof value !== "string" || value.startsWith("--")) {
+        throw new Error(`${name} requires a value`);
+    }
+    return value;
 }
 
 function isReleaseVersion(value) {


### PR DESCRIPTION
## What changed

- run the existing release dry-run in the required quality workflow
- add a path-scoped Windows x64 package smoke workflow for pull requests and manual runs
- sync the real MFAA, MXU, MaaFramework, OCR, Python, and dependency runtimes before building
- require both `package-mfaa` and `package-mxu` to be generated
- pass an explicit SemVer test tag to the real package builder without weakening release-tag validation
- use each package's embedded Python to import all declared runtime dependencies plus the Agent entry modules
- compile the packaged Agent tree to catch missing or invalid Python files
- cancel stale package smoke runs when a PR is updated

## Why

The template migration removed the previous pull-request packaging checks. As a result, packaging regressions were only discovered during tag releases. The regular quality check remains fast, while release-affecting pull requests now get one representative real package build on the primary Windows x64 target.

## Security and cost

The workflow uses only a read-only `GITHUB_TOKEN`; it does not expose the private drop_core token, upload the large package, or run for documentation-only changes.

## Local validation

- Prettier passed for both workflows
- actionlint v1.7.12 passed for both workflows
- `node tools/check-project.mjs`
- `pnpm check:py` — Ruff, Pyright, and 41 pytest tests passed
- `pnpm release:dry-run`

The pull request's new `Windows x64 package smoke` check is the authoritative real-package validation for this change.

## Summary by Sourcery

为 PR 和手动运行引入 Windows x64 软件包冒烟测试工作流，并将发布 dry-run 接入主质量检查流程。

新功能：
- 新增一个路径范围限定的 Windows x64 软件包冒烟测试 CI 任务，为符合条件的拉取请求和 `workflow_dispatch` 运行构建真实软件包。

增强内容：
- 允许 `build-release` 脚本在未打标签的验证构建中接受一个显式的类 SemVer 的发布标签覆盖值。
- 验证生成的 Windows 软件包是否包含必需的 `package-mfaa` 和 `package-mxu` 目录、内嵌的 Python、是否导入所有声明的运行时依赖，以及是否能成功编译 Agent 树。

CI：
- 扩展必需检查工作流，将现有的发布 dry-run 作为标准质量流水线的一部分运行。
- 增加并发控制，在拉取请求更新时取消过期的软件包冒烟测试运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a Windows x64 package smoke workflow for PRs and manual runs and wire release dry-run into the main quality check.

New Features:
- Add a path-scoped Windows x64 package smoke CI job that builds real packages for qualifying pull requests and workflow_dispatch runs.

Enhancements:
- Allow build-release script to accept an explicit SemVer-like release tag override for non-tagged validation builds.
- Verify generated Windows packages include required package-mfaa and package-mxu directories, embedded Python, import all declared runtime dependencies, and successfully compile the Agent tree.

CI:
- Extend the required check workflow to run the existing release dry-run as part of the standard quality pipeline.
- Add concurrency controls to cancel stale package smoke runs when pull requests are updated.

</details>