### PR TITLE
fix(schema): validate nested task files

### DIFF
--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -1,0 +1,27 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_schema_validator_rejects_invalid_nested_task(tmp_path: Path) -> None:
+    shutil.copytree(PROJECT_ROOT / "tools" / "schema", tmp_path / "tools" / "schema")
+    shutil.copy2(PROJECT_ROOT / "interface.json", tmp_path / "interface.json")
+    shutil.copy2(PROJECT_ROOT / "package.json", tmp_path / "package.json")
+    nested_task = tmp_path / "tasks" / "presets" / "invalid.json"
+    nested_task.parent.mkdir(parents=True)
+    nested_task.write_text("[]\n", encoding="utf-8")
+
+    result = subprocess.run(
+        ["node", str(PROJECT_ROOT / "tools" / "validate-schema.mjs")],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = f"{result.stdout}\n{result.stderr}".replace("\\", "/")
+
+    assert result.returncode == 1
+    assert "tasks/presets/invalid.json" in output
+    assert "must be object" in output

--- a/tools/validate-schema.mjs
+++ b/tools/validate-schema.mjs
@@ -114,12 +114,10 @@ function* walkJsonFiles(dir) {
 // interface.json
 validateFile("interface.json", interfaceValidator);
 
-// tasks/*.json
+// tasks/**/*.json
 if (existsSync("tasks")) {
-    for (const file of readdirSync("tasks")) {
-        if (file.endsWith(".json") || file.endsWith(".jsonc")) {
-            validateFile(join("tasks", file), taskValidator);
-        }
+    for (const file of walkJsonFiles("tasks")) {
+        validateFile(file, taskValidator);
     }
 }
 


### PR DESCRIPTION
# Pull Request

## 关联 Issue / Related Issue

框架审计发现 `tools/validate-schema.mjs` 只校验 `tasks/` 第一层，实际存在的 `tasks/preset/*.json` 会被跳过。模板共性修复见 Windsland52/create-maa-project#1。

## 变更摘要 / Summary

- 复用已有 `walkJsonFiles`，递归校验 `tasks/**/*.json(c)`
- 添加进程级回归测试，验证嵌套的非法 task 文件会导致校验失败
- 不修改任务内容、pipeline 或 workflow

## 验证 / Validation

- [x] 回归测试修复前失败：校验进程返回 0，未输出嵌套文件路径
- [x] `uv run --frozen pytest tests/test_schema_validator.py -q` — 1 passed
- [x] `pnpm check:schema` — 通过，并实际校验 `tasks/preset/*.json`
- [x] `pnpm check:maa` — 通过（仅保留既有 `EventName` warnings）
- [x] `pnpm lint` — 通过
- [x] `pnpm check:py` — Ruff、Pyright、42 tests 全部通过
- [x] `pnpm release:dry-run` — MFAA/MXU 六平台矩阵通过
- [x] 变更文件分别通过 Prettier 与 Ruff format check
- [ ] `pnpm check` — 本机全目录 Prettier 会扫描 Git 忽略的 `work/` 模板审计目录；由干净 GitHub Actions 环境完成最终确认

## 影响范围 / Impact

仅影响本地 schema 校验工具。现有 `tasks/preset/*.json` 从此前未校验变为纳入校验；不改变运行时任务行为。

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

回归输入为 `tasks/presets/invalid.json`（根值 `[]`）；修复后校验器返回 1，并报告该路径 `must be object`。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [x] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.（无用户可见变化 / N/A）
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Summary by Sourcery

将模式验证范围扩展到嵌套的任务文件，并添加回归测试，确保无效的嵌套任务会被清晰的错误信息拒绝。

Bug Fixes:
- 将 `tasks/` 目录下的嵌套 JSON/JSONC 文件纳入模式验证范围，弥补它们之前被跳过的漏洞。

Tests:
- 添加一个回归测试，以子进程方式运行模式验证器，并断言无效的嵌套任务文件会导致非零退出码，同时在输出中报告其路径和错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand schema validation to cover nested task files and add regression coverage to ensure invalid nested tasks are rejected with clear errors.

Bug Fixes:
- Include nested JSON/JSONC files under tasks/ in schema validation to close a gap where they were previously skipped.

Tests:
- Add a regression test that runs the schema validator as a subprocess and asserts invalid nested task files cause a non-zero exit and report their path and error message.

</details>

Bug 修复：
- 确保 `tasks/` 下的嵌套任务 JSON/JSONC 文件被包含在模式验证中。

测试：
- 添加一个回归测试，用于验证模式验证器会拒绝无效的嵌套任务文件并报告它们的路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将模式验证范围扩展到嵌套的任务文件，并添加回归测试，确保无效的嵌套任务会被清晰的错误信息拒绝。

Bug Fixes:
- 将 `tasks/` 目录下的嵌套 JSON/JSONC 文件纳入模式验证范围，弥补它们之前被跳过的漏洞。

Tests:
- 添加一个回归测试，以子进程方式运行模式验证器，并断言无效的嵌套任务文件会导致非零退出码，同时在输出中报告其路径和错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand schema validation to cover nested task files and add regression coverage to ensure invalid nested tasks are rejected with clear errors.

Bug Fixes:
- Include nested JSON/JSONC files under tasks/ in schema validation to close a gap where they were previously skipped.

Tests:
- Add a regression test that runs the schema validator as a subprocess and asserts invalid nested task files cause a non-zero exit and report their path and error message.

</details>

</details>