### PR TITLE
fix(release): exclude Python cache files

### DIFF
--- a/tests/test_release_builder.py
+++ b/tests/test_release_builder.py
@@ -1,0 +1,68 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def test_release_package_excludes_python_cache_files(tmp_path: Path) -> None:
+    write_json(tmp_path / "maa-project.lock.json", {"pending": []})
+    write_json(
+        tmp_path / "maa-project.json",
+        {"runtime": {"mfa": {"enabled": True}, "mxu": {"enabled": False}}},
+    )
+    write_json(
+        tmp_path / "interface.json",
+        {
+            "name": "m9a",
+            "version": "v0.1.0",
+            "resource": [],
+            "import": [],
+            "agent": [{}],
+        },
+    )
+
+    for relative_path in (
+        "tasks",
+        "resource",
+        "runtimes/win-x64/native",
+        "libs/MaaAgentBinary",
+        "plugins",
+        "agent/__pycache__",
+        ".create-maa-project/runtime/mfaa/win-x64",
+        ".create-maa-project/runtime/python/win-x64",
+    ):
+        (tmp_path / relative_path).mkdir(parents=True)
+
+    (tmp_path / "runtimes/win-x64/native/MaaPiCli.exe").write_bytes(b"cli")
+    (tmp_path / ".create-maa-project/runtime/mfaa/win-x64/MFAAvalonia.exe").write_bytes(b"gui")
+    (tmp_path / ".create-maa-project/runtime/python/win-x64/python.exe").write_bytes(b"python")
+    (tmp_path / "agent/bootstrap.py").write_text("# bootstrap\n", encoding="utf-8")
+    (tmp_path / "agent/__pycache__/main.cpython-313.pyc").write_bytes(b"cache")
+    (tmp_path / "agent/main.pyo").write_bytes(b"cache")
+    (tmp_path / "requirements.txt").write_text("maafw\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "node",
+            str(PROJECT_ROOT / "tools" / "build-release.mjs"),
+            "--release-tag",
+            "v0.0.0-test",
+        ],
+        cwd=tmp_path,
+        env={**os.environ, "CREATE_MAA_PROJECT_RUNTIME_PLATFORM": "win-x64"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    package_agent = tmp_path / "dist/package-mfaa/agent"
+    assert (package_agent / "bootstrap.py").is_file()
+    assert not (package_agent / "__pycache__").exists()
+    assert not (package_agent / "main.pyo").exists()

--- a/tools/build-release.mjs
+++ b/tools/build-release.mjs
@@ -315,7 +315,8 @@ function prepareReleasePackage(guiKey, gui, packagePaths, interfaceJson, runtime
         copyPath("logo.ico", join(pkgDir, "logo.ico"));
     }
     for (const path of packagePaths) {
-        copyPath(path, join(pkgDir, releasePackagePath(path)));
+        const options = path === "agent" ? {filter: shouldCopyAgentPath} : {};
+        copyPath(path, join(pkgDir, releasePackagePath(path)), options);
     }
     for (const path of optionalPackagePaths()) {
         if (existsSync(path)) {
@@ -478,6 +479,11 @@ function copyDirectoryContents(source, target, options = {}) {
     for (const entry of readdirSync(source)) {
         copyPath(join(source, entry), join(target, entry), options);
     }
+}
+
+function shouldCopyAgentPath(source) {
+    const name = basename(source).toLowerCase();
+    return name !== "__pycache__" && !name.endsWith(".pyc") && !name.endsWith(".pyo");
 }
 
 function shouldCopyMxuMaafwPath(source) {


### PR DESCRIPTION
# Pull Request

## 关联 Issue / Related Issue

框架审计发现发布构建会递归复制本地 `agent/`，从而把 Python 字节码缓存带入交付包。模板共性修复见 Windsland52/create-maa-project#3。

## 变更摘要 / Summary

- 仅在复制 `agent/` 源码时排除 `__pycache__`、`.pyc` 和 `.pyo`
- 保持 GUI runtime、嵌入式 Python、资源和其他发布输入的复制行为不变
- 添加隔离的进程级 pytest，直接运行真实 `tools/build-release.mjs`

## 验证 / Validation

- [x] 回归测试修复前失败：真实构建成功，但 `dist/package-mfaa/agent/__pycache__` 存在
- [x] `uv run --frozen pytest tests/test_release_builder.py -q` — 1 passed
- [x] `pnpm check:py` — Ruff、Pyright、43 tests 全部通过
- [x] `pnpm check:schema` — 通过
- [x] `pnpm check:maa` — 通过（仅保留既有 `EventName` warnings）
- [x] `pnpm lint` — 通过
- [x] `pnpm release:dry-run` — MFAA/MXU 六平台矩阵通过
- [x] 变更文件分别通过 Prettier 与 Ruff format check
- [ ] `pnpm check` — 本机全目录 Prettier 会扫描 Git 忽略的 `work/` 审计目录；由干净 GitHub Actions 环境完成最终确认
- [ ] Windows x64 Package Smoke — 由本 PR 的 path-scoped workflow 完成真实 runtime 打包验证

## 影响范围 / Impact

仅影响发布包中的 `agent/` 复制过滤。任务、pipeline、运行时代码和 workflow 均未修改。

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

回归夹具在临时目录构造最小 Windows x64 MFAA 项目，并验证正常源码保留、两类缓存产物消失。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [x] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.（无用户可见流程变化 / N/A）
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Summary by Sourcery

在保留代理源文件和其他发布输入的前提下，将 Python 缓存制品排除在发布包之外。

Bug Fixes:
- 防止代理目录中的 Python 字节码缓存文件被包含进发布包。

Tests:
- 添加一种集成风格的 pytest 测试，通过调用真实的发布构建脚本来验证：在排除 Python 缓存文件的同时，代理源文件会被保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Exclude Python cache artifacts from release packages while preserving agent source files and other release inputs.

Bug Fixes:
- Prevent Python bytecode cache files in the agent directory from being included in release packages.

Tests:
- Add an integration-style pytest that invokes the real release builder script to verify agent source files are kept while Python cache files are excluded.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保留代理源文件和其他发布输入的前提下，将 Python 缓存制品排除在发布包之外。

Bug Fixes:
- 防止代理目录中的 Python 字节码缓存文件被包含进发布包。

Tests:
- 添加一种集成风格的 pytest 测试，通过调用真实的发布构建脚本来验证：在排除 Python 缓存文件的同时，代理源文件会被保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Exclude Python cache artifacts from release packages while preserving agent source files and other release inputs.

Bug Fixes:
- Prevent Python bytecode cache files in the agent directory from being included in release packages.

Tests:
- Add an integration-style pytest that invokes the real release builder script to verify agent source files are kept while Python cache files are excluded.

</details>

</details>