### PR TITLE
fix(paths): reject project root escapes

### DIFF
--- a/tests/test_release_builder.py
+++ b/tests/test_release_builder.py
@@ -10,19 +10,20 @@ def write_json(path: Path, value: object) -> None:
     path.write_text(json.dumps(value), encoding="utf-8")
 
 
-def test_release_package_excludes_python_cache_files(tmp_path: Path) -> None:
-    write_json(tmp_path / "maa-project.lock.json", {"pending": []})
+def prepare_release_project(root: Path, imports: list[str] | None = None) -> None:
+    root.mkdir(exist_ok=True)
+    write_json(root / "maa-project.lock.json", {"pending": []})
     write_json(
-        tmp_path / "maa-project.json",
+        root / "maa-project.json",
         {"runtime": {"mfa": {"enabled": True}, "mxu": {"enabled": False}}},
     )
     write_json(
-        tmp_path / "interface.json",
+        root / "interface.json",
         {
             "name": "m9a",
             "version": "v0.1.0",
             "resource": [],
-            "import": [],
+            "import": imports or [],
             "agent": [{}],
         },
     )
@@ -37,32 +38,53 @@ def test_release_package_excludes_python_cache_files(tmp_path: Path) -> None:
         ".create-maa-project/runtime/mfaa/win-x64",
         ".create-maa-project/runtime/python/win-x64",
     ):
-        (tmp_path / relative_path).mkdir(parents=True)
+        (root / relative_path).mkdir(parents=True)
 
-    (tmp_path / "runtimes/win-x64/native/MaaPiCli.exe").write_bytes(b"cli")
-    (tmp_path / ".create-maa-project/runtime/mfaa/win-x64/MFAAvalonia.exe").write_bytes(b"gui")
-    (tmp_path / ".create-maa-project/runtime/python/win-x64/python.exe").write_bytes(b"python")
-    (tmp_path / "agent/bootstrap.py").write_text("# bootstrap\n", encoding="utf-8")
-    (tmp_path / "agent/__pycache__/main.cpython-313.pyc").write_bytes(b"cache")
-    (tmp_path / "agent/main.pyo").write_bytes(b"cache")
-    (tmp_path / "requirements.txt").write_text("maafw\n", encoding="utf-8")
+    (root / "runtimes/win-x64/native/MaaPiCli.exe").write_bytes(b"cli")
+    (root / ".create-maa-project/runtime/mfaa/win-x64/MFAAvalonia.exe").write_bytes(b"gui")
+    (root / ".create-maa-project/runtime/python/win-x64/python.exe").write_bytes(b"python")
+    (root / "agent/bootstrap.py").write_text("# bootstrap\n", encoding="utf-8")
+    (root / "agent/__pycache__/main.cpython-313.pyc").write_bytes(b"cache")
+    (root / "agent/main.pyo").write_bytes(b"cache")
+    (root / "requirements.txt").write_text("maafw\n", encoding="utf-8")
 
-    result = subprocess.run(
+
+def run_release_builder(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
         [
             "node",
             str(PROJECT_ROOT / "tools" / "build-release.mjs"),
             "--release-tag",
             "v0.0.0-test",
         ],
-        cwd=tmp_path,
+        cwd=root,
         env={**os.environ, "CREATE_MAA_PROJECT_RUNTIME_PLATFORM": "win-x64"},
         capture_output=True,
         text=True,
         check=False,
     )
 
+
+def test_release_package_excludes_python_cache_files(tmp_path: Path) -> None:
+    prepare_release_project(tmp_path)
+    result = run_release_builder(tmp_path)
+
     assert result.returncode == 0, result.stdout + result.stderr
     package_agent = tmp_path / "dist/package-mfaa/agent"
     assert (package_agent / "bootstrap.py").is_file()
     assert not (package_agent / "__pycache__").exists()
     assert not (package_agent / "main.pyo").exists()
+
+
+def test_release_builder_rejects_paths_outside_project_root(tmp_path: Path) -> None:
+    outside_path = tmp_path / "outside.json"
+    outside_path.write_text("{}\n", encoding="utf-8")
+
+    for index, unsafe_path in enumerate(("../outside.json", outside_path.resolve().as_posix())):
+        project_root = tmp_path / f"project-{index}"
+        prepare_release_project(project_root, [unsafe_path])
+
+        result = run_release_builder(project_root)
+
+        assert result.returncode != 0
+        assert "release paths must stay within the project root" in result.stdout + result.stderr

--- a/tools/build-release.mjs
+++ b/tools/build-release.mjs
@@ -133,6 +133,9 @@ for (const path of [
     if (path.includes("\\")) {
         throw new Error(`release paths must use forward slashes: ${path}`);
     }
+    if (!isProjectRelativePath(path)) {
+        throw new Error(`release paths must stay within the project root: ${path}`);
+    }
     const relativePath = path.startsWith("./") ? path.slice(2) : path;
     if (!existsSync(relativePath)) {
         throw new Error(`release referenced path does not exist: ${path}`);
@@ -255,6 +258,11 @@ function strings(value) {
 
 function interfaceResourcePaths(value) {
     return Array.isArray(value) ? value.flatMap((item) => (isRecord(item) ? strings(item.path) : [])) : [];
+}
+
+function isProjectRelativePath(path) {
+    const stripped = path.startsWith("./") ? path.slice(2) : path;
+    return !stripped.startsWith("/") && !/^[A-Za-z]:/.test(stripped) && !stripped.split("/").includes("..");
 }
 
 function releasePackagePaths(interfaceJson, runtimePlatform, guiKey) {

--- a/tools/check-project.mjs
+++ b/tools/check-project.mjs
@@ -215,6 +215,9 @@ for (const path of [
     if (typeof path !== "string" || path.includes("\\")) {
         throw new Error("interface/import paths must be strings with forward slashes");
     }
+    if (!isProjectRelativePath(path)) {
+        throw new Error(`interface/import paths must stay within the project root: ${path}`);
+    }
     if (!existsSync(path)) {
         throw new Error(`referenced path does not exist: ${path}`);
     }
@@ -408,6 +411,11 @@ function isRecord(value) {
 
 function stripDotSlash(path) {
     return path.startsWith("./") ? path.slice(2) : path;
+}
+
+function isProjectRelativePath(path) {
+    const stripped = stripDotSlash(path);
+    return !stripped.startsWith("/") && !/^[A-Za-z]:/.test(stripped) && !stripped.split("/").includes("..");
 }
 
 function expectedPackageScripts(project) {


### PR DESCRIPTION
# Pull Request

## 关联 Issue / Related Issue

框架审计发现 interface resource/import 引用只检查正斜杠和存在性，真实存在的 `../outside.json` 或绝对路径可逃逸项目根目录。模板共性修复见 Windsland52/create-maa-project#4。

## 变更摘要 / Summary

- 在项目结构检查与 release builder 中拒绝绝对路径、Windows 盘符路径和独立 `..` 段
- 保留现有正斜杠与存在性校验
- 扩展隔离 release-builder 回归测试，覆盖父目录逃逸与绝对路径

## 验证 / Validation

- [x] 回归测试修复前失败：构建因后续 package smoke 报错，而不是在项目根边界拒绝引用
- [x] `uv run --frozen pytest tests/test_release_builder.py -q` — 2 passed
- [x] `pnpm check:py` — Ruff、Pyright、44 tests 全部通过
- [x] `pnpm lint` — 实际 M9A 合法引用通过
- [x] `pnpm check:schema` — 通过
- [x] `pnpm check:maa` — 通过（仅保留既有 `EventName` warnings）
- [x] `pnpm release:dry-run` — MFAA/MXU 六平台矩阵通过
- [x] 变更文件分别通过 Prettier 与 Ruff format check
- [ ] `pnpm check` — 本机全目录 Prettier 会扫描 Git 忽略的 `work/` 审计目录；由干净 GitHub Actions 环境完成最终确认
- [ ] Windows x64 Package Smoke — 由本 PR 的 path-scoped workflow 完成真实 runtime 打包验证

## 影响范围 / Impact

仅收紧项目/发布引用路径边界。现有项目内相对路径不变；任务与 pipeline 内容未修改。

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

边界判断平台无关：去掉可选 `./` 后，拒绝 `/` 开头、`X:` 盘符开头或包含独立 `..` 段的路径。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [x] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.（仅错误校验收紧 / N/A）
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Summary by Sourcery

强制接口导入和发布资源使用相对于项目根目录的路径，防止路径逃逸。

Bug 修复：
- 拒绝使用绝对路径、Windows 盘符前缀或父目录段（`..`）来逃逸项目根目录的发布路径和接口/导入路径。

增强：
- 重构发布构建器（release builder）的测试，以共享项目设置和执行辅助工具。

测试：
- 扩展发布构建器的回归测试，以覆盖对项目根目录之外路径的拒绝情况，包括父目录路径和绝对路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce project-root-relative paths for interface imports and release resources to prevent path escapes.

Bug Fixes:
- Reject release and interface/import paths that use absolute paths, Windows drive prefixes, or parent directory segments to escape the project root.

Enhancements:
- Refactor release builder tests to share project setup and execution helpers.

Tests:
- Extend release builder regression tests to cover rejection of paths outside the project root, including parent-directory and absolute paths.

</details>

Bug Fixes（错误修复）:
- 拒绝通过绝对路径、Windows 驱动器号或父目录段（`..`）逃出项目根目录的 interface/import 和 release 路径。

Enhancements（增强）:
- 重构 release builder 测试，用于共享项目准备与执行的辅助函数。

Tests（测试）:
- 添加回归测试，确保当接口导入引用项目根目录之外的文件时，release builder 会失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

强制接口导入和发布资源使用相对于项目根目录的路径，防止路径逃逸。

Bug 修复：
- 拒绝使用绝对路径、Windows 盘符前缀或父目录段（`..`）来逃逸项目根目录的发布路径和接口/导入路径。

增强：
- 重构发布构建器（release builder）的测试，以共享项目设置和执行辅助工具。

测试：
- 扩展发布构建器的回归测试，以覆盖对项目根目录之外路径的拒绝情况，包括父目录路径和绝对路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce project-root-relative paths for interface imports and release resources to prevent path escapes.

Bug Fixes:
- Reject release and interface/import paths that use absolute paths, Windows drive prefixes, or parent directory segments to escape the project root.

Enhancements:
- Refactor release builder tests to share project setup and execution helpers.

Tests:
- Extend release builder regression tests to cover rejection of paths outside the project root, including parent-directory and absolute paths.

</details>

</details>