### PR TITLE
fix(release): fail when no artifacts are built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,8 +171,13 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          for pkg_dir in dist/package-*; do
-            [ -d "$pkg_dir" ] || continue
+          shopt -s nullglob
+          package_dirs=(dist/package-*)
+          if (( ${#package_dirs[@]} == 0 )); then
+            echo "[ERR] no release packages were generated"
+            exit 1
+          fi
+          for pkg_dir in "${package_dirs[@]}"; do
             gui=$(basename "$pkg_dir" | sed 's/^package-//')
             gui_upper=$(echo "$gui" | tr '[:lower:]' '[:upper:]')
             archive="M9A-${{ matrix.artifact_os }}-${{ matrix.arch }}-${GITHUB_REF_NAME}-${gui_upper}.${{ matrix.ext }}"
@@ -197,6 +202,7 @@ jobs:
         with:
           name: ${{ matrix.artifact_os }}-${{ matrix.arch }}
           path: dist/*
+          if-no-files-found: error
 
   git_cliff:
     name: Generate release notes

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_workflow_fails_without_package_artifacts() -> None:
+    workflow = (PROJECT_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("package_dirs=(dist/package-*)") == 2
+    assert "if (( ${#package_dirs[@]} == 0 )); then" in workflow
+    assert 'for pkg_dir in "${package_dirs[@]}"; do' in workflow
+    assert 'echo "[ERR] no release packages were generated"' in workflow
+    assert "if-no-files-found: error" in workflow


### PR DESCRIPTION
# Pull Request

## 关联 Issue / Related Issue

框架审计发现 Release 的通用 Package step 在没有 `dist/package-*` 时会静默结束；现有检查只覆盖 `drop_core_supported` 平台，Windows ARM64 等路径仍可能无产物成功。模板共性修复见 Windsland52/create-maa-project#5。

## 变更摘要 / Summary

- Package step 使用 `nullglob` 数组并要求至少一个 package 目录
- `actions/upload-artifact` 设置 `if-no-files-found: error`
- 添加 workflow 契约测试，确保通用门禁不会退化

## 验证 / Validation

- [x] 回归测试修复前失败：workflow 没有通用空包门禁，且 upload-artifact 未配置 error
- [x] `uv run --frozen pytest tests/test_release_workflow.py -q` — 1 passed
- [x] `pnpm check:py` — Ruff、Pyright、45 tests 全部通过
- [x] `pnpm lint` — 通过
- [x] `pnpm release:dry-run` — MFAA/MXU 六平台矩阵通过
- [x] `actionlint .github/workflows/release.yml` — 通过
- [x] 变更文件分别通过 Prettier 与 Ruff format check
- [ ] `pnpm check` — 本机全目录 Prettier 会扫描 Git 忽略的 `work/` 审计目录；由干净 GitHub Actions 环境完成最终确认
- [ ] Windows x64 Package Smoke — 由本 PR 的 path-scoped workflow 完成真实 runtime 打包验证

## 影响范围 / Impact

仅收紧 Release workflow 的失败条件；任务、pipeline、构建器和运行时代码均未修改。

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

受支持 drop_core 平台原有校验保留；本次增加的是所有矩阵平台都会经过的通用门禁。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [x] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.（CI 失败策略 / N/A）
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Summary by Sourcery

收紧发布工作流，以便在未生成任何包构件时任务会失败，并确保这一行为由测试覆盖。

Bug Fixes:
- 确保当未生成任何 `dist/package-*` 目录时，发布打包步骤会显式失败。
- 将构件上传配置为在未找到文件时抛出错误，而不是在无文件情况下仍然静默成功。

Tests:
- 添加一个工作流契约测试，以断言发布流水线强制要求非空的包构件，并严格执行构件上传行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the release workflow so that jobs fail when no package artifacts are produced and ensure this behavior is covered by tests.

Bug Fixes:
- Ensure the release packaging step fails explicitly when no dist/package-* directories are generated.
- Configure artifact upload to error when no files are found instead of silently succeeding.

Tests:
- Add a workflow contract test to assert the release pipeline enforces non-empty package artifacts and strict artifact upload behavior.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

收紧发布工作流，以便在未生成任何包构件时任务会失败，并确保这一行为由测试覆盖。

Bug Fixes:
- 确保当未生成任何 `dist/package-*` 目录时，发布打包步骤会显式失败。
- 将构件上传配置为在未找到文件时抛出错误，而不是在无文件情况下仍然静默成功。

Tests:
- 添加一个工作流契约测试，以断言发布流水线强制要求非空的包构件，并严格执行构件上传行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the release workflow so that jobs fail when no package artifacts are produced and ensure this behavior is covered by tests.

Bug Fixes:
- Ensure the release packaging step fails explicitly when no dist/package-* directories are generated.
- Configure artifact upload to error when no files are found instead of silently succeeding.

Tests:
- Add a workflow contract test to assert the release pipeline enforces non-empty package artifacts and strict artifact upload behavior.

</details>

</details>