### PR TITLE
fix(agent): install complete requirements

### DIFF
--- a/agent/bootstrap.py
+++ b/agent/bootstrap.py
@@ -157,10 +157,6 @@ def ensure_requirements_installed(project_root: Path, requirements: Path, digest
 
 
 def needs_requirement_install(project_root: Path, digest: str) -> bool:
-    if is_package_installed("maafw") and not is_running_in_project_venv(project_root):
-        log(project_root, "maafw is already installed in current Python")
-        return False
-
     marker = requirements_marker(project_root)
     if marker.exists() and marker.read_text(encoding="utf8").strip() == digest:
         if is_package_installed("maafw"):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from agent import bootstrap
+
+
+def test_external_maafw_without_marker_does_not_skip_requirements(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(bootstrap, "is_package_installed", lambda _name: True)
+    monkeypatch.setattr(bootstrap, "is_running_in_project_venv", lambda _root: False)
+
+    assert bootstrap.needs_requirement_install(tmp_path, "digest") is True
+
+
+def test_matching_marker_skips_reinstall_when_maafw_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "debug" / bootstrap.REQUIREMENTS_MARKER
+    marker.parent.mkdir()
+    marker.write_text("digest\n", encoding="utf8")
+    monkeypatch.setattr(bootstrap, "is_package_installed", lambda _name: True)
+    monkeypatch.setattr(bootstrap, "is_running_in_project_venv", lambda _root: False)
+
+    assert bootstrap.needs_requirement_install(tmp_path, "digest") is False


### PR DESCRIPTION
# Pull Request

## 关联 Issue / Related Issue

框架审计发现 bootstrap 在项目外部 Python 已安装 `maafw` 时，会把它误当作整份 requirements 已满足并跳过安装。模板共性修复见 Windsland52/create-maa-project#2。

## 变更摘要 / Summary

- 删除 `maafw` 单包存在即跳过完整 requirements 的错误短路
- 保留 requirements 摘要成功标记作为重复安装缓存
- 添加无标记与有效标记两个 pytest 回归用例

## 验证 / Validation

- [x] 回归测试修复前失败：已有 `maafw`、无成功标记时返回 `False`
- [x] `uv run --frozen pytest tests/test_bootstrap.py -q` — 2 passed
- [x] `pnpm check:py` — Ruff、Pyright、47 tests 全部通过
- [x] `pnpm lint` — 通过
- [x] `pnpm release:dry-run` — MFAA/MXU 六平台矩阵通过
- [x] `uv run --frozen ruff format --check agent/bootstrap.py tests/test_bootstrap.py` — 通过
- [ ] `pnpm check` — 本机全目录 Prettier 会扫描 Git 忽略的 `work/` 审计目录；由干净 GitHub Actions 环境完成最终确认
- [ ] Windows x64 Package Smoke — 由本 PR 的 path-scoped workflow 完成真实 Agent 打包验证

## 影响范围 / Impact

仅影响 Agent 启动时的依赖安装判定。已有成功摘要标记的环境仍跳过重复安装；任务与 pipeline 未修改。

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

修复后首次启动会对整份 requirements 执行一次安装并写入摘要标记，而不会仅因 `maafw` 已存在而跳过。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [x] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.（启动依赖修复，无文档变更 / N/A）
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Summary by Sourcery

修复代理在引导阶段安装依赖的逻辑，避免在只有 maafw 存在时跳过完整安装，同时继续使用摘要标记（digest marker）来缓存成功的安装结果。

Bug Fixes:
- 防止代理将外部安装的 maafw 包视为所有依赖项已满足的证据。

Tests:
- 新增回归测试，以覆盖在存在 maafw 但无标记时的依赖安装场景，以及在存在匹配标记时应跳过重新安装的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix agent bootstrap requirement installation logic to avoid skipping full installs when only maafw is present while still using a digest marker to cache successful installs.

Bug Fixes:
- Prevent agent from treating an externally installed maafw package as evidence that all requirements are already satisfied.

Tests:
- Add regression tests to cover requirement installation when maafw is present without a marker and when a matching marker should skip reinstallation.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复代理在引导阶段安装依赖的逻辑，避免在只有 maafw 存在时跳过完整安装，同时继续使用摘要标记（digest marker）来缓存成功的安装结果。

Bug Fixes:
- 防止代理将外部安装的 maafw 包视为所有依赖项已满足的证据。

Tests:
- 新增回归测试，以覆盖在存在 maafw 但无标记时的依赖安装场景，以及在存在匹配标记时应跳过重新安装的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix agent bootstrap requirement installation logic to avoid skipping full installs when only maafw is present while still using a digest marker to cache successful installs.

Bug Fixes:
- Prevent agent from treating an externally installed maafw package as evidence that all requirements are already satisfied.

Tests:
- Add regression tests to cover requirement installation when maafw is present without a marker and when a matching marker should skip reinstallation.

</details>

</details>