### PR TITLE
fix(paths): reject empty project paths

### DIFF
--- a/tests/test_release_builder.py
+++ b/tests/test_release_builder.py
@@ -80,7 +80,7 @@ def test_release_builder_rejects_paths_outside_project_root(tmp_path: Path) -> N
     outside_path = tmp_path / "outside.json"
     outside_path.write_text("{}\n", encoding="utf-8")
 
-    for index, unsafe_path in enumerate(("../outside.json", outside_path.resolve().as_posix())):
+    for index, unsafe_path in enumerate(("", ".", "../outside.json", outside_path.resolve().as_posix())):
         project_root = tmp_path / f"project-{index}"
         prepare_release_project(project_root, [unsafe_path])
 

--- a/tools/build-release.mjs
+++ b/tools/build-release.mjs
@@ -262,7 +262,13 @@ function interfaceResourcePaths(value) {
 
 function isProjectRelativePath(path) {
     const stripped = path.startsWith("./") ? path.slice(2) : path;
-    return !stripped.startsWith("/") && !/^[A-Za-z]:/.test(stripped) && !stripped.split("/").includes("..");
+    return (
+        stripped !== "" &&
+        stripped !== "." &&
+        !stripped.startsWith("/") &&
+        !/^[A-Za-z]:/.test(stripped) &&
+        !stripped.split("/").includes("..")
+    );
 }
 
 function releasePackagePaths(interfaceJson, runtimePlatform, guiKey) {

--- a/tools/check-project.mjs
+++ b/tools/check-project.mjs
@@ -415,7 +415,13 @@ function stripDotSlash(path) {
 
 function isProjectRelativePath(path) {
     const stripped = stripDotSlash(path);
-    return !stripped.startsWith("/") && !/^[A-Za-z]:/.test(stripped) && !stripped.split("/").includes("..");
+    return (
+        stripped !== "" &&
+        stripped !== "." &&
+        !stripped.startsWith("/") &&
+        !/^[A-Za-z]:/.test(stripped) &&
+        !stripped.split("/").includes("..")
+    );
 }
 
 function expectedPackageScripts(project) {


### PR DESCRIPTION
## Summary

- reject empty and dot-only interface paths in project checks and release builds
- cover both invalid path forms in the release-builder regression test

## Root cause

The shared path-boundary checks rejected absolute paths and `..` segments, but still accepted `""` and `"."`. That allowed a missing path to reach later filesystem checks and allowed the project root itself to be treated as a referenced file path.

## Validation

- `pnpm check:py` (47 tests passed)
- `pnpm exec prettier --check tools/check-project.mjs tools/build-release.mjs`
- `pnpm check:schema`
- `pnpm check:maa`
- `pnpm lint`
- `pnpm release:dry-run`

## 由 Sourcery 提供的摘要

拒绝空路径和仅包含“.” 的项目接口路径，并扩展发布构建器测试以覆盖这些无效路径形式。

Bug 修复：
- 在项目检查和发布构建中，将空路径和仅包含“.” 的接口路径视为无效的项目相对路径。
- 通过收紧项目相对路径的校验，防止将项目根目录误解为被引用的文件路径。

测试：
- 扩展发布构建器的回归测试，以覆盖空路径、仅包含“.” 的路径、父级相对路径以及绝对接口路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reject empty and dot-only project interface paths and extend release builder tests to cover these invalid path forms.

Bug Fixes:
- Treat empty and dot-only interface paths as invalid project-relative paths in project checks and release builds.
- Prevent the project root from being interpreted as a referenced file path by tightening project-relative path validation.

Tests:
- Expand the release builder regression test to cover empty, dot-only, parent-relative, and absolute interface paths.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

拒绝空路径和仅包含“.” 的项目接口路径，并扩展发布构建器测试以覆盖这些无效路径形式。

Bug 修复：
- 在项目检查和发布构建中，将空路径和仅包含“.” 的接口路径视为无效的项目相对路径。
- 通过收紧项目相对路径的校验，防止将项目根目录误解为被引用的文件路径。

测试：
- 扩展发布构建器的回归测试，以覆盖空路径、仅包含“.” 的路径、父级相对路径以及绝对接口路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reject empty and dot-only project interface paths and extend release builder tests to cover these invalid path forms.

Bug Fixes:
- Treat empty and dot-only interface paths as invalid project-relative paths in project checks and release builds.
- Prevent the project root from being interpreted as a referenced file path by tightening project-relative path validation.

Tests:
- Expand the release builder regression test to cover empty, dot-only, parent-relative, and absolute interface paths.

</details>

</details>