### PR TITLE
fix(release): match package directories only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         shell: bash
         run: |
           shopt -s nullglob
-          package_dirs=(dist/package-*)
+          package_dirs=(dist/package-*/)
           if (( ${#package_dirs[@]} == 0 )); then
             echo "[ERR] no release packages were generated for a supported drop_core target"
             exit 1
@@ -172,7 +172,7 @@ jobs:
         run: |
           mkdir -p dist
           shopt -s nullglob
-          package_dirs=(dist/package-*)
+          package_dirs=(dist/package-*/)
           if (( ${#package_dirs[@]} == 0 )); then
             echo "[ERR] no release packages were generated"
             exit 1

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -6,7 +6,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 def test_release_workflow_fails_without_package_artifacts() -> None:
     workflow = (PROJECT_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
 
-    assert workflow.count("package_dirs=(dist/package-*)") == 2
+    assert workflow.count("package_dirs=(dist/package-*/)") == 2
     assert "if (( ${#package_dirs[@]} == 0 )); then" in workflow
     assert 'for pkg_dir in "${package_dirs[@]}"; do' in workflow
     assert 'echo "[ERR] no release packages were generated"' in workflow


### PR DESCRIPTION
## Summary

- make both release workflow globs match package directories only
- update the workflow regression test to require the directory-only form

## Root cause

`dist/package-*` also matches regular files. A stray file with that prefix could therefore be counted as a generated package and then passed to directory-only archive or module checks. The trailing slash in `dist/package-*/` makes Bash include directories only while preserving `nullglob` failure handling.

## Validation

- `pnpm check:py` (47 tests passed)
- `pnpm exec prettier --check .github/workflows/release.yml`
- `work/actionlint/bin/actionlint.exe .github/workflows/release.yml`
- `pnpm release:dry-run`

## Summary by Sourcery

确保发布工作流只将包目录视为生成的发布制品，并使工作流回归测试与这一行为保持一致。

Bug Fixes（错误修复）：
- 防止匹配包通配符的零散文件被视为生成的发布包。

Tests（测试）：
- 收紧发布工作流回归测试，要求仅使用目录形式的包通配符模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the release workflow only treats package directories as generated release artifacts and keep the workflow regression test aligned with this behavior.

Bug Fixes:
- Prevent stray files matching the package glob from being treated as generated release packages.

Tests:
- Tighten the release workflow regression test to require the directory-only package glob pattern.

</details>

错误修复：
- 防止与包的通配模式匹配的杂散文件被当作生成的发布包处理。

测试：
- 收紧发布工作流回归测试，要求使用仅匹配目录的包通配模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保发布工作流只将包目录视为生成的发布制品，并使工作流回归测试与这一行为保持一致。

Bug Fixes（错误修复）：
- 防止匹配包通配符的零散文件被视为生成的发布包。

Tests（测试）：
- 收紧发布工作流回归测试，要求仅使用目录形式的包通配符模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the release workflow only treats package directories as generated release artifacts and keep the workflow regression test aligned with this behavior.

Bug Fixes:
- Prevent stray files matching the package glob from being treated as generated release packages.

Tests:
- Tighten the release workflow regression test to require the directory-only package glob pattern.

</details>

</details>