### PR TITLE
feat: 为 ModifyPCRegistry.ps1添加了日服支持

### DIFF
--- a/docs/en_us/manual/newbie.md
+++ b/docs/en_us/manual/newbie.md
@@ -268,6 +268,16 @@ Can't change to `16:9` ratio when using the International Version PC client? Use
     </li>
     <li>
       <details>
+        <summary>Step 0</summary>
+          <ol>
+            <li>After opening, select option 3 to switch between EN (International) and JP (Japan) servers</li>
+            <li>The current server is displayed at the top of the menu</li>
+          </ol>
+          <img src="/images/en-us/newbie-init-script-step1.webp" alt="Step 0">
+      </details>
+    </li>
+    <li>
+      <details>
         <summary>Step 1</summary>
           <ol>
             <li>After opening, enter 1 in the command line</li>

--- a/docs/zh_cn/manual/newbie.md
+++ b/docs/zh_cn/manual/newbie.md
@@ -269,6 +269,16 @@ M9A 支持主流模拟器与PC端，但您需要设置模拟器与PC端分辨率
     </li>
     <li>
       <details>
+        <summary>步骤0</summary>
+          <ol>
+            <li>打开后，选择选项3切换服务器：EN（国际服）或 JP（日服）</li>
+            <li>当前服务器显示在菜单顶部</li>
+          </ol>
+          <img src="/images/zh-cn/newbie-init-script-step1.webp" alt="步骤0">
+      </details>
+    </li>
+    <li>
+      <details>
         <summary>步骤1</summary>
           <ol>
             <li>打开后在命令行输入1</li>

--- a/tools/registry/ModifyPCRegistry.ps1
+++ b/tools/registry/ModifyPCRegistry.ps1
@@ -215,7 +215,7 @@ if (-not $hasResolutionParams) {
                 Start-Sleep -Seconds 2
             }
             '3' {
-                # Switch server (cycle: EN -> CN -> JP -> EN)
+                # Switch server (cycle: EN -> JP -> EN)
                 $Server = if ($Server -eq 'EN') { 'JP' } else { 'EN' }
                 if (-not $keyPathExplicit) {
                     $KeyPath = if ($Server -eq 'JP') {

--- a/tools/registry/ModifyPCRegistry.ps1
+++ b/tools/registry/ModifyPCRegistry.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 modify_resolution.ps1
 Safe helper to backup a registry key and update a Resolution-like value to "WIDTH * HEIGHT" or a custom string.
 - Preserves the original registry value kind when possible (REG_BINARY/REG_SZ/REG_DWORD/etc).
@@ -21,10 +21,12 @@ pwsh .\modify_resolution.ps1 -KeyPath 'HKCU:\Software\bluepoch' -BackupFile '.\b
 #>
 
 param(
-    [string]$KeyPath = 'HKCU:\Software\bluepoch\Reverse: 1999',
+    [string]$KeyPath,
     [string]$ValueName = 'ResolutionRatio_h997442698',
     [ValidateSet('1','2','3','4','5','6')]
     [string]$Preset,
+    [ValidateSet('EN','JP')]
+    [string]$Server = 'EN',
     [int]$Width,
     [int]$Height,
     [string]$NewValue,
@@ -33,6 +35,16 @@ param(
     [switch]$Force,
     [switch]$NoGameDefaults
 )
+
+# Set default KeyPath based on server if not explicitly provided
+$keyPathExplicit = $PSBoundParameters.ContainsKey('KeyPath')
+if (-not $keyPathExplicit) {
+    $KeyPath = if ($Server -eq 'JP') {
+        'HKCU:\Software\bluepoch\リバース：1999'
+    } else {
+        'HKCU:\Software\bluepoch\Reverse: 1999'
+    }
+}
 
 # Centralized resolution presets
 $resolutionPresets = @(
@@ -90,8 +102,8 @@ function Set-RegistryValueSafe($regKey, $valueName, $newValue, $preferredKind) {
 }
 
 # Function to set game default values
-function Set-GameDefaults($regKey) {
-    Write-Host "Setting game default values..."
+function Set-GameDefaults($regKey, $server) {
+    Write-Host "Setting game default values ($server)..."
     
     # Screenmanager Fullscreen mode = 3 (windowed mode)
     try {
@@ -101,11 +113,12 @@ function Set-GameDefaults($regKey) {
         Write-Warning "  Failed to set Screenmanager Fullscreen mode: $_"
     }
     
-    # SdkLanguage = "zh_CN" (Binary, ASCII encoded with null terminator)
+    # SdkLanguage based on server
+    $sdkLang = if ($server -eq 'JP') { 'ja' } else { 'en' }
     try {
-        $sdkBytes = [System.Text.Encoding]::ASCII.GetBytes('zh_CN' + "`0")
+        $sdkBytes = [System.Text.Encoding]::ASCII.GetBytes($sdkLang + "`0")
         $regKey.SetValue('SdkLanguage_h2445173579', $sdkBytes, [Microsoft.Win32.RegistryValueKind]::Binary)
-        Write-Host "  Set SdkLanguage_h2445173579 = zh_CN (Binary, ASCII)"
+        Write-Host "  Set SdkLanguage_h2445173579 = $sdkLang (Binary, ASCII)"
     } catch {
         Write-Warning "  Failed to set SdkLanguage: $_"
     }
@@ -141,23 +154,29 @@ if ($Restore) {
 }
 
 # Determine desired value string
-# If no parameters provided, run an interactive main menu
-if ($PSBoundParameters.Count -eq 0 -and -not $Restore) {
+# If no resolution parameters provided, run an interactive main menu
+$hasResolutionParams = $PSBoundParameters.ContainsKey('Width') -or $PSBoundParameters.ContainsKey('Height') -or $PSBoundParameters.ContainsKey('NewValue') -or $PSBoundParameters.ContainsKey('Preset') -or $Restore
+if (-not $hasResolutionParams) {
     while ($true) {
         Clear-Host
         Write-Host "================ Main Menu ================"
+        Write-Host "Current server: $Server"
+        Write-Host "KeyPath: $KeyPath"
+        Write-Host ""
         Write-Host "Select an action:"
         Write-Host "1) Set resolution from preset"
         Write-Host "2) Restore from backup (import .reg)"
-        Write-Host "3) Exit"
+        Write-Host "3) Switch server (currently: $Server)"
+        Write-Host "4) Exit"
         Write-Host "=========================================="
-        $action = Read-Host "Enter choice (1-3)"
+        $action = Read-Host "Enter choice (1-4)"
 
         switch ($action) {
             '1' {
                 while ($true) {
                     Clear-Host
-                    Write-Host "Presets (will also set game defaults: windowed mode, zh_CN language):"
+                    $langLabel = if ($Server -eq 'JP') { 'ja' } else { 'en' }
+                    Write-Host "Presets (will also set game defaults: windowed mode, $langLabel language):"
                     foreach ($res in $resolutionPresets) {
                         Write-Host "  $($res.Label): $($res.Description)"
                     }
@@ -195,7 +214,20 @@ if ($PSBoundParameters.Count -eq 0 -and -not $Restore) {
                 if ($confirmExit.ToLower() -eq 'y') { Write-Host "Exiting."; exit 0 }
                 Start-Sleep -Seconds 2
             }
-            '3' { Write-Host "Exiting."; exit 0 }
+            '3' {
+                # Switch server (cycle: EN -> CN -> JP -> EN)
+                $Server = if ($Server -eq 'EN') { 'JP' } else { 'EN' }
+                if (-not $keyPathExplicit) {
+                    $KeyPath = if ($Server -eq 'JP') {
+                        'HKCU:\Software\bluepoch\リバース：1999'
+                    } else {
+                        'HKCU:\Software\bluepoch\Reverse: 1999'
+                    }
+                }
+                Write-Host "Switched to server: $Server"
+                Start-Sleep -Seconds 1
+            }
+            '4' { Write-Host "Exiting."; exit 0 }
             default { Write-Host "Invalid choice."; Start-Sleep -Seconds 1 }
         }
         # If a resolution was selected, exit the main loop to proceed with modification
@@ -223,9 +255,10 @@ if ($PSBoundParameters.Count -eq 0 -and -not $Restore) {
 # Confirm
 if (-not $Force) {
     Write-Host "About to modify registry key: $KeyPath, value: $ValueName"
+    Write-Host "Server: $Server"
     Write-Host "New value: $valueToSet"
     if (-not $NoGameDefaults) {
-        Write-Host "Note: This will also set game defaults (windowed mode, zh_CN language, etc.)"
+        Write-Host "Note: This will also set game defaults (windowed mode, language, etc.)"
     }
     $ok = Read-Host "Proceed? (y/N)"
     if ($ok.ToLower() -ne 'y') { Write-Host "Aborted."; exit 0 }
@@ -358,7 +391,7 @@ try {
     # If not disabled, set game defaults for all resolutions
     if (-not $NoGameDefaults) {
         Write-Host ""
-        Set-GameDefaults -regKey $key
+        Set-GameDefaults -regKey $key -server $Server
     }
 
 } catch {


### PR DESCRIPTION
## 关联 Issue / Related Issue

无。

## 变更摘要 / Summary

- 新增 `-Server` 参数，支持 EN / JP 双服务器，KeyPath 根据服务端自动切换
- 交互菜单增加服务器切换功能（选项 3 循环 EN ↔ JP）
- 日服模式下 SdkLanguage 自动设为 `ja`，KeyPath 切换到 `HKCU:\Software\bluepoch\リバース：1999`
- 更新文档 `newbie.md`（中/英），在 PC 端初始化教程中增加步骤 0 说明服务器选择

## 验证 / Validation

- [x] `pnpm check`
- [x] 在开发者设备 Windows 11 专业版 25H2 (OS Build 26200.8037) 上测试，成功切换日服游戏客户端分辨率

## 影响范围 / Impact

- `tools/registry/ModifyPCRegistry.ps1`
- `docs/en_us/manual/newbie.md`
- `docs/zh_cn/manual/newbie.md`

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

无。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [x] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Summary by Sourcery

为 PC 注册表修改脚本新增 JP 服务器支持，并更新新手引导文档，以说明在交互式流程中进行服务器选择。

New Features:
- 引入 `-Server` 参数，提供 EN 和 JP 选项，可自动选择对应的注册表键路径。
- 扩展交互式菜单，在应用分辨率预设之前显示并切换当前活动服务器。

Enhancements:
- 使游戏的默认语言选择依赖所选服务器，为 EN 和 JP 客户端正确设置 `SdkLanguage`。

Documentation:
- 更新英文和中文新手指南，记录在 PC 初始化脚本流程中新增加的服务器选择步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add JP server support to the PC registry modification script and update onboarding docs to describe server selection in the interactive flow.

New Features:
- Introduce a -Server parameter with EN and JP options that automatically selects the appropriate registry key path.
- Extend the interactive menu to display and switch the active server before applying resolution presets.

Enhancements:
- Make game default language selection depend on the chosen server, setting SdkLanguage appropriately for EN and JP clients.

Documentation:
- Update English and Chinese newbie guides to document the new server selection step in the PC initialization script workflow.

</details>