### PR TITLE
fix: 修复当期活动代币刷取在切换复现界面卡住的问题

### DIFF
--- a/data/activity/cn.json
+++ b/data/activity/cn.json
@@ -1112,6 +1112,13 @@
                                 535
                             ]
                         }
+                    },
+                    "SwitchToReplay":{
+                        "recognition": {
+                        "param": {
+                                "roi":[841,624,56,64]
+                            }
+                        }
                     }
                 }
             }

--- a/data/activity/cn.json
+++ b/data/activity/cn.json
@@ -1113,10 +1113,15 @@
                             ]
                         }
                     },
-                    "SwitchToReplay":{
+                    "SwitchToReplay": {
                         "recognition": {
-                        "param": {
-                                "roi":[841,624,56,64]
+                            "param": {
+                                "roi": [
+                                    841,
+                                    624,
+                                    56,
+                                    64
+                                ]
                             }
                         }
                     }

--- a/data/activity/en.json
+++ b/data/activity/en.json
@@ -793,6 +793,18 @@
                                 535
                             ]
                         }
+                    },
+                    "SwitchToReplay": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    841,
+                                    624,
+                                    56,
+                                    64
+                                ]
+                            }
+                        }
                     }
                 }
             }

--- a/data/activity/jp.json
+++ b/data/activity/jp.json
@@ -793,6 +793,18 @@
                                 535
                             ]
                         }
+                    },
+                    "SwitchToReplay": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    841,
+                                    624,
+                                    56,
+                                    64
+                                ]
+                            }
+                        }
                     }
                 }
             }

--- a/data/activity/tw.json
+++ b/data/activity/tw.json
@@ -610,6 +610,18 @@
                                 535
                             ]
                         }
+                    },
+                    "SwitchToReplay": {
+                        "recognition": {
+                            "param": {
+                                "roi": [
+                                    841,
+                                    624,
+                                    56,
+                                    64
+                                ]
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
活动关卡复现图标roi位置不对

## Summary by Sourcery

Bug Fixes:
- 修正中文活动数据中活动复现图标的 ROI 配置，防止复现界面卡住无法继续。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the ROI configuration for the activity reproduction icon in the Chinese activity data to prevent the reproduction screen from getting stuck.

</details>