### PR TITLE
feat: 中英双语化 ModifyPCRegistry.ps1

### DIFF
--- a/tools/registry/ModifyPCRegistry.ps1
+++ b/tools/registry/ModifyPCRegistry.ps1
@@ -148,7 +148,7 @@ if ($Restore) {
     Write-Host "正在从以下路径导入备份 / Importing backup from: $BackupFile"
     $imp = Start-Process -FilePath reg -ArgumentList "import `"$BackupFile`"" -NoNewWindow -Wait -PassThru
     if ($imp.ExitCode -ne 0) {
-        Write-ErrAndExit "reg import 失败 (退出码 $imp.ExitCode) / reg import failed (exit code $imp.ExitCode)"
+        Write-ErrAndExit "reg import 失败 (退出码 $($imp.ExitCode)) / reg import failed (exit code $($imp.ExitCode))"
     }
     Write-Host "恢复完成 / Restore completed."
     exit 0

--- a/tools/registry/ModifyPCRegistry.ps1
+++ b/tools/registry/ModifyPCRegistry.ps1
@@ -4,7 +4,8 @@ Safe helper to backup a registry key and update a Resolution-like value to "WIDT
 - Preserves the original registry value kind when possible (REG_BINARY/REG_SZ/REG_DWORD/etc).
 - Backs up the whole key with `reg export` before modifying.
 - Offers a `-Restore` switch to import the backup.
-- Automatically sets game defaults (fullscreen mode=3, language=zh_CN, etc.) for all resolutions unless -NoGameDefaults is used.
+- Automatically sets game defaults (fullscreen mode=3, language=en/ja, etc.) for all resolutions unless -NoGameDefaults is used.
+- Bilingual UI: every prompt is shown in both Chinese and English.
 
 Usage examples:
 # Backup & set to 1920 x 1080 (will also set game defaults)
@@ -93,63 +94,63 @@ function Set-RegistryValueSafe($regKey, $valueName, $newValue, $preferredKind) {
                 $regKey.SetValue($valueName, $newValue, [Microsoft.Win32.RegistryValueKind]::String)
             }
         }
-        Write-Host "  Set $valueName = $newValue (type: $existingKind)"
+        Write-Host "  已设置 / Set $valueName = $newValue (type: $existingKind)"
         return $true
     } catch {
-        Write-Warning "  Failed to set $valueName : $_"
+        Write-Warning "  设置失败 / Failed to set $valueName : $_"
         return $false
     }
 }
 
 # Function to set game default values
 function Set-GameDefaults($regKey, $server) {
-    Write-Host "Setting game default values ($server)..."
-    
+    Write-Host "正在设置游戏默认项 ($server) / Setting game default values ($server)..."
+
     # Screenmanager Fullscreen mode = 3 (windowed mode)
     try {
         $regKey.SetValue('Screenmanager Fullscreen mode_h3630240806', 3, [Microsoft.Win32.RegistryValueKind]::DWord)
-        Write-Host "  Set Screenmanager Fullscreen mode_h3630240806 = 3 (DWord)"
+        Write-Host "  Screenmanager Fullscreen mode_h3630240806 = 3 (DWord)"
     } catch {
-        Write-Warning "  Failed to set Screenmanager Fullscreen mode: $_"
+        Write-Warning "  设置 Screenmanager Fullscreen mode 失败 / Failed to set Screenmanager Fullscreen mode: $_"
     }
-    
+
     # SdkLanguage based on server
     $sdkLang = if ($server -eq 'JP') { 'ja' } else { 'en' }
     try {
         $sdkBytes = [System.Text.Encoding]::ASCII.GetBytes($sdkLang + "`0")
         $regKey.SetValue('SdkLanguage_h2445173579', $sdkBytes, [Microsoft.Win32.RegistryValueKind]::Binary)
-        Write-Host "  Set SdkLanguage_h2445173579 = $sdkLang (Binary, ASCII)"
+        Write-Host "  SdkLanguage_h2445173579 = $sdkLang (Binary, ASCII)"
     } catch {
-        Write-Warning "  Failed to set SdkLanguage: $_"
+        Write-Warning "  设置 SdkLanguage 失败 / Failed to set SdkLanguage: $_"
     }
-    
+
     # CurLanguageType = 1 (DWord)
     try {
         $regKey.SetValue('CurLanguageType_h2647185547', 1, [Microsoft.Win32.RegistryValueKind]::DWord)
-        Write-Host "  Set CurLanguageType_h2647185547 = 1 (DWord)"
+        Write-Host "  CurLanguageType_h2647185547 = 1 (DWord)"
     } catch {
-        Write-Warning "  Failed to set CurLanguageType: $_"
+        Write-Warning "  设置 CurLanguageType 失败 / Failed to set CurLanguageType: $_"
     }
-    
-    Write-Host "Game defaults set."
+
+    Write-Host "游戏默认项已设置完成 / Game defaults set."
 }
 
 # Normalize KeyPath
 if ($KeyPath -notmatch '^(HKCU|HKLM|HKCR|HKU|HKCC):\\') {
-    Write-ErrAndExit "KeyPath must start with one of HKCU:/HKLM:/HKCR:/HKU:/HKCC:. Example: 'HKCU:\\Software\\bluepoch'"
+    Write-ErrAndExit "KeyPath 必须以 HKCU:/HKLM:/HKCR:/HKU:/HKCC: 之一开头 / KeyPath must start with one of HKCU:/HKLM:/HKCR:/HKU:/HKCC:. Example: 'HKCU:\\Software\\bluepoch'"
 }
 
 if ($Restore) {
     if (-not (Test-Path $BackupFile)) {
-        Write-ErrAndExit "Backup file '$BackupFile' not found."
+        Write-ErrAndExit "未找到备份文件 / Backup file not found: $BackupFile"
     }
 
-    Write-Host "Importing backup from: $BackupFile"
+    Write-Host "正在从以下路径导入备份 / Importing backup from: $BackupFile"
     $imp = Start-Process -FilePath reg -ArgumentList "import `"$BackupFile`"" -NoNewWindow -Wait -PassThru
     if ($imp.ExitCode -ne 0) {
-        Write-ErrAndExit "reg import failed (exit code $($imp.ExitCode))."
+        Write-ErrAndExit "reg import 失败 (退出码 $imp.ExitCode) / reg import failed (exit code $imp.ExitCode)"
     }
-    Write-Host "Restore completed."
+    Write-Host "恢复完成 / Restore completed."
     exit 0
 }
 
@@ -159,33 +160,33 @@ $hasResolutionParams = $PSBoundParameters.ContainsKey('Width') -or $PSBoundParam
 if (-not $hasResolutionParams) {
     while ($true) {
         Clear-Host
-        Write-Host "================ Main Menu ================"
-        Write-Host "Current server: $Server"
-        Write-Host "KeyPath: $KeyPath"
+        Write-Host "================ 主菜单 / Main Menu ================"
+        Write-Host "当前游戏服务器 / Current server: $Server"
+        Write-Host "注册表路径 / KeyPath: $KeyPath"
         Write-Host ""
-        Write-Host "Select an action:"
-        Write-Host "1) Set resolution from preset"
-        Write-Host "2) Restore from backup (import .reg)"
-        Write-Host "3) Switch server (currently: $Server)"
-        Write-Host "4) Exit"
-        Write-Host "=========================================="
-        $action = Read-Host "Enter choice (1-4)"
+        Write-Host "请选择操作 / Select an action:"
+        Write-Host "1) 从预设分辨率中选择 / Set resolution from preset"
+        Write-Host "2) 从备份恢复（导入 .reg 文件） / Restore from backup (import .reg)"
+        Write-Host "3) 切换游戏服务器（当前: $Server） / Switch server (currently: $Server)"
+        Write-Host "4) 退出 / Exit"
+        Write-Host "==================================================="
+        $action = Read-Host "请输入选项 / Enter choice (1-4)"
 
         switch ($action) {
             '1' {
-                while ($true) {
+                :presetLoop while ($true) {
                     Clear-Host
                     $langLabel = if ($Server -eq 'JP') { 'ja' } else { 'en' }
-                    Write-Host "Presets (will also set game defaults: windowed mode, $langLabel language):"
+                    Write-Host "预设分辨率（同时设置游戏默认项：窗口模式、$langLabel 语言） / Presets (will also set game defaults: windowed mode, $langLabel language):"
                     foreach ($res in $resolutionPresets) {
                         Write-Host "  $($res.Label): $($res.Description)"
                     }
-                    Write-Host "  q) Return to main menu"
+                    Write-Host "  q) 返回主菜单 / Return to main menu"
                     $presetLabels = ($resolutionPresets | ForEach-Object { $_.Label }) -join ', '
-                    $p = Read-Host "Choose preset ($presetLabels) or 'q' to return"
+                    $p = Read-Host "请选择预设 ($presetLabels) 或输入 'q' 返回 / Choose preset ($presetLabels) or 'q' to return"
 
                     if ($p -eq 'q' -or $p -eq 'Q') {
-                        Write-Host "Returning to main menu..."
+                        Write-Host "正在返回主菜单 / Returning to main menu..."
                         Start-Sleep -Seconds 1
                         break  # Break inner loop to return to main menu
                     }
@@ -195,23 +196,38 @@ if (-not $hasResolutionParams) {
                         $Width = $selectedPreset.Width
                         $Height = $selectedPreset.Height
                         $valueToSet = "{0} * {1}" -f $Width, $Height
+                        # Interactive confirm: N goes back to preset loop, Y proceeds
+                        if (-not $Force) {
+                            Clear-Host
+                            Write-Host "即将修改注册表项 / About to modify registry key: $KeyPath, value: $ValueName"
+                            Write-Host "服务器 / Server: $Server"
+                            Write-Host "新值 / New value: $valueToSet"
+                            if (-not $NoGameDefaults) {
+                                Write-Host "提示 / Note: 还会同时设置游戏默认项（窗口模式、语言等） / This will also set game defaults (windowed mode, language, etc.)"
+                            }
+                            $ok = Read-Host "是否继续？(y/N，输入 N 返回重新选择) / Proceed? (y/N, enter N to go back)"
+                            if ($ok.ToLower() -ne 'y') {
+                                $valueToSet = $null
+                                continue presetLoop
+                            }
+                        }
                         break  # Exit preset selection loop after valid choice
                     } else {
-                        Write-Host "Invalid preset choice."; Start-Sleep -Seconds 1
+                        Write-Host "无效的预设选项 / Invalid preset choice."; Start-Sleep -Seconds 1
                     }
                 }
                 if ($valueToSet) { break }  # Exit main menu loop if a resolution was chosen
             }
             '2' {
                 # Restore flow
-                $bk = Read-Host "Enter backup .reg path to import (or press Enter to use default $BackupFile)"
+                $bk = Read-Host "请输入要导入的备份 .reg 路径（留空使用默认 $BackupFile） / Enter backup .reg path to import (or press Enter to use default $BackupFile)"
                 if ($bk -ne '') { $BackupFile = $bk }
-                if (-not (Test-Path $BackupFile)) { Write-Host "Backup file not found: $BackupFile"; Start-Sleep -Seconds 2; continue }
-                Write-Host "Importing backup from: $BackupFile"
+                if (-not (Test-Path $BackupFile)) { Write-Host "未找到备份文件 / Backup file not found: $BackupFile"; Start-Sleep -Seconds 2; continue }
+                Write-Host "正在从以下路径导入备份 / Importing backup from: $BackupFile"
                 Start-Process -FilePath reg -ArgumentList "import `"$BackupFile`"" -NoNewWindow -Wait
-                Write-Host "Restore completed."
-                $confirmExit = Read-Host "Exit? (y/N)"
-                if ($confirmExit.ToLower() -eq 'y') { Write-Host "Exiting."; exit 0 }
+                Write-Host "恢复完成 / Restore completed."
+                $confirmExit = Read-Host "是否退出 / Exit? (y/N)"
+                if ($confirmExit.ToLower() -eq 'y') { Write-Host "已退出 / Exiting."; exit 0 }
                 Start-Sleep -Seconds 2
             }
             '3' {
@@ -224,11 +240,11 @@ if (-not $hasResolutionParams) {
                         'HKCU:\Software\bluepoch\Reverse: 1999'
                     }
                 }
-                Write-Host "Switched to server: $Server"
+                Write-Host "已切换到游戏服务器 / Switched to server: $Server"
                 Start-Sleep -Seconds 1
             }
-            '4' { Write-Host "Exiting."; exit 0 }
-            default { Write-Host "Invalid choice."; Start-Sleep -Seconds 1 }
+            '4' { Write-Host "已退出 / Exiting."; exit 0 }
+            default { Write-Host "无效的选项 / Invalid choice."; Start-Sleep -Seconds 1 }
         }
         # If a resolution was selected, exit the main loop to proceed with modification
         if ($valueToSet) { break }
@@ -252,20 +268,20 @@ if (-not $hasResolutionParams) {
     }
 }
 
-# Confirm
-if (-not $Force) {
-    Write-Host "About to modify registry key: $KeyPath, value: $ValueName"
-    Write-Host "Server: $Server"
-    Write-Host "New value: $valueToSet"
+# Confirm for parameter mode (interactive mode is confirmed inside the preset loop)
+if ($hasResolutionParams -and -not $Force) {
+    Write-Host "即将修改注册表项 / About to modify registry key: $KeyPath, value: $ValueName"
+    Write-Host "服务器 / Server: $Server"
+    Write-Host "新值 / New value: $valueToSet"
     if (-not $NoGameDefaults) {
-        Write-Host "Note: This will also set game defaults (windowed mode, language, etc.)"
+        Write-Host "提示 / Note: 还会同时设置游戏默认项（窗口模式、语言等） / This will also set game defaults (windowed mode, language, etc.)"
     }
-    $ok = Read-Host "Proceed? (y/N)"
-    if ($ok.ToLower() -ne 'y') { Write-Host "Aborted."; exit 0 }
+    $ok = Read-Host "是否继续 / Proceed? (y/N)"
+    if ($ok.ToLower() -ne 'y') { Write-Host "已取消 / Aborted."; exit 0 }
 }
 
 # Export backup
-Write-Host "Exporting registry key to: $BackupFile"
+Write-Host "正在导出注册表项到 / Exporting registry key to: $BackupFile"
 $exportTarget = $KeyPath
 
 # Convert PowerShell provider path (HKCU:\...) to reg.exe path (HKCU\...)
@@ -279,29 +295,29 @@ function Convert-ToRegKey([string]$psKey) {
 $regExportTarget = Convert-ToRegKey $exportTarget
 $export = Start-Process -FilePath reg -ArgumentList "export `"$regExportTarget`" `"$BackupFile`" /y" -NoNewWindow -Wait -PassThru
 if ($export.ExitCode -ne 0) {
-    Write-Host "reg export failed for key '$exportTarget' (exit code $($export.ExitCode)). Trying parent key export..."
+    Write-Host "reg export 失败 (键: '$exportTarget', 退出码 $($export.ExitCode))。尝试导出父键 / reg export failed for key '$exportTarget' (exit code $($export.ExitCode)). Trying parent key export..."
     # Try exporting parent key if child key name contains characters unsupported by reg.exe (eg. colon)
     try {
         $lastSlash = $KeyPath.LastIndexOf('\')
         if ($lastSlash -gt 0) {
             $parentKey = $KeyPath.Substring(0, $lastSlash)
-            Write-Host "Attempting to export parent key: $parentKey"
+            Write-Host "正在尝试导出父键 / Attempting to export parent key: $parentKey"
             $regParent = Convert-ToRegKey $parentKey
             $export = Start-Process -FilePath reg -ArgumentList "export `"$regParent`" `"$BackupFile`" /y" -NoNewWindow -Wait -PassThru
             if ($export.ExitCode -ne 0) {
-                Write-ErrAndExit "reg export failed for parent key '$parentKey' (exit code $($export.ExitCode)). Aborting."
+                Write-ErrAndExit "reg export 父键失败 ('$parentKey', 退出码 $($export.ExitCode))。中止 / reg export failed for parent key '$parentKey' (exit code $($export.ExitCode)). Aborting."
             } else {
-                Write-Host "Parent key exported to $BackupFile. Note: backup contains parent key, not the exact subkey path."
+                Write-Host "父键已导出到 $BackupFile。注意: 备份包含父键而非精确子键路径 / Parent key exported to $BackupFile. Note: backup contains parent key, not the exact subkey path."
                 $exportTarget = $parentKey
             }
         } else {
-            Write-ErrAndExit "reg export failed and no parent key available. Aborting."
+            Write-ErrAndExit "reg export 失败且无父键可用。中止 / reg export failed and no parent key available. Aborting."
         }
     } catch {
-        Write-ErrAndExit "reg export failed and parent export attempt raised error: $_"
+        Write-ErrAndExit "reg export 失败且父键导出报错 / reg export failed and parent export attempt raised error: $_"
     }
 } else {
-    Write-Host "Backup exported."
+    Write-Host "备份已导出 / Backup exported."
 }
 
 # Parse hive and subkey
@@ -326,9 +342,9 @@ switch ($hive) {
 try {
     $key = $base.OpenSubKey($sub, $true)
 } catch {
-    Write-ErrAndExit "Failed to open registry key: $KeyPath. $_"
+    Write-ErrAndExit "打开注册表项失败 / Failed to open registry key: $KeyPath. $_"
 }
-if (-not $key) { Write-ErrAndExit "Registry key not found: $KeyPath" }
+if (-not $key) { Write-ErrAndExit "未找到注册表项 / Registry key not found: $KeyPath" }
 
 # Read existing value and kind
 try {
@@ -340,8 +356,8 @@ try {
     $currentKind = [Microsoft.Win32.RegistryValueKind]::String
 }
 
-Write-Host "Current value kind: $currentKind"
-if ($null -ne $currentValue) { Write-Host "Current value (raw): $currentValue" } else { Write-Host "Value did not exist previously; will create as string or binary based on default." }
+Write-Host "当前值类型 / Current value kind: $currentKind"
+if ($null -ne $currentValue) { Write-Host "当前值 (原始) / Current value (raw): $currentValue" } else { Write-Host "值原本不存在；将根据默认类型创建为 string 或 binary / Value did not exist previously; will create as string or binary based on default." }
 
 # Attempt set
 try {
@@ -357,7 +373,7 @@ try {
             if ([int]::TryParse($valueToSet, [ref]$num)) {
                 $key.SetValue($ValueName, $num, [Microsoft.Win32.RegistryValueKind]::DWord)
             } else {
-                Write-Host "Provided value is not an integer; writing as string instead (preserving original as backup)."
+                Write-Host "提供的值不是整数；改为按 string 写入（已备份原值） / Provided value is not an integer; writing as string instead (preserving original as backup)."
                 $key.SetValue($ValueName, $valueToSet, [Microsoft.Win32.RegistryValueKind]::String)
             }
         }
@@ -376,17 +392,17 @@ try {
         }
     }
 
-    Write-Host "Value written. Verifying..."
+    Write-Host "值已写入。正在校验 / Value written. Verifying..."
     $new = $key.GetValue($ValueName)
     $newKind = $key.GetValueKind($ValueName)
-    Write-Host "Read back kind: $newKind"
+    Write-Host "回读类型 / Read back kind: $newKind"
     if ($newKind -eq [Microsoft.Win32.RegistryValueKind]::Binary) {
         # show as ASCII if printable
         try {
             $astext = [System.Text.Encoding]::ASCII.GetString($new)
-            Write-Host "Read back (as ASCII): $astext"
-        } catch { Write-Host "Read back (binary): $new" }
-    } else { Write-Host "Read back: $new" }
+            Write-Host "回读 (ASCII) / Read back (as ASCII): $astext"
+        } catch { Write-Host "回读 (binary) / Read back (binary): $new" }
+    } else { Write-Host "回读 / Read back: $new" }
 
     # If not disabled, set game defaults for all resolutions
     if (-not $NoGameDefaults) {
@@ -395,13 +411,13 @@ try {
     }
 
 } catch {
-    Write-Error "Failed to write registry value: $_"
-    Write-Host "Attempting to restore from backup: $BackupFile"
+    Write-Error "写入注册表值失败 / Failed to write registry value: $_"
+    Write-Host "正在尝试从备份恢复 / Attempting to restore from backup: $BackupFile"
     if (Test-Path $BackupFile) {
         Start-Process -FilePath reg -ArgumentList "import `"$BackupFile`"" -NoNewWindow -Wait
-        Write-Host "Restore attempted."
+        Write-Host "已尝试恢复 / Restore attempted."
     }
     exit 1
 }
 
-Write-Host "Done."
+Write-Host "完成 / Done."


### PR DESCRIPTION
## 改动说明

将 `tools/registry/ModifyPCRegistry.ps1` 的所有 UI 提示改为中英双语格式，方便国际服 PC 端的中文/英文用户使用。

## 主要变更

- 所有 `Write-Host` / `Write-Warning` / `Read-Host` / `Write-Error` 提示改为中英双语格式（用 ` / ` 分隔）
- 主菜单、预设选择、备份恢复、确认区、错误提示、Set-GameDefaults 函数全部覆盖
- 新增 `:presetLoop` 标签，让交互模式下输入 `N` 取消时**返回分辨率选择**（而非退出整个脚本）
- Confirm 区行为按调用入口分离：
  - **参数模式** (`-Width` 等)：`N` 仍退出脚本
  - **交互模式**：`N` 退回预设子菜单，`Y` 进入主流程
- 保留注册表值名（如 `Screenmanager Fullscreen mode_h3630240806`）、类型后缀（`(DWord)`/`(Binary, ASCII)`）、技术值为英文
- 保留脚本作者注释、`param` 块为英文（保证命令行互操作）
- 保留 `-Force` / `-Restore` / `-NoGameDefaults` / `-Width` / `-Height` / `-Preset` / `-NewValue` 等所有参数行为

## 测试场景

- [x] 无参数启动 → 中文菜单 (Windows zh-CN) / English menu
- [x] 主菜单 1) 选预设 → N 取消 → 退回预设子菜单
- [x] 主菜单 3) 切换游戏服务器 (EN ↔ JP)
- [x] 主菜单 4) 退出
- [x] `-Width 1920 -Height 1080` 参数模式 → 双语确认
- [x] `-Restore -BackupFile xxx.reg` 恢复模式
- [x] `-Force` 跳过所有确认

## 影响范围

仅 `tools/registry/ModifyPCRegistry.ps1` 一个文件，91 insertions / 75 deletions。

不修改 `tools/registry/游戏PC端注册表修改_ModifyPCRegistry.bat`（包装脚本仍为英文）。

## Summary by Sourcery

为 PC 注册表修改脚本添加中英文双语 UI 消息，并优化交互流程。

New Features:
- 在 `ModifyPCRegistry.ps1` 中，以中英双语显示所有交互式提示、菜单和状态消息。

Enhancements:
- 调整交互式预设选择逻辑，使取消操作返回预设菜单，而不是直接退出脚本。
- 区分参数模式和交互模式下的确认行为，同时保持现有参数模式的语义不变。
- 改进备份、还原和错误消息，使用更加清晰、描述性更强的双语输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add bilingual Chinese/English UI messaging to the PC registry modification script and refine interactive flows.

New Features:
- Display all interactive prompts, menus, and status messages in both Chinese and English in ModifyPCRegistry.ps1.

Enhancements:
- Adjust interactive preset selection so cancelling returns to the preset menu instead of exiting the script.
- Differentiate confirmation behavior between parameter mode and interactive mode while preserving existing parameter-mode semantics.
- Improve backup, restore, and error messages with clearer, more descriptive bilingual output.

</details>

新功能：
- 在交互模式和参数模式下，以中英双语显示所有脚本提示、菜单和状态消息。

增强优化：
- 调整交互式预设选择逻辑，使取消操作返回预设菜单，而不是直接退出脚本。
- 区分参数模式与交互模式下的确认行为：在交互模式中在预设流程内部进行确认，同时保持参数模式原有的语义和行为不变。
- 明确并丰富备份/导出、恢复以及错误消息的内容，以更符合用户习惯的双语方式更好地描述操作过程和失败原因。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 PC 注册表修改脚本添加中英文双语 UI 消息，并优化交互流程。

New Features:
- 在 `ModifyPCRegistry.ps1` 中，以中英双语显示所有交互式提示、菜单和状态消息。

Enhancements:
- 调整交互式预设选择逻辑，使取消操作返回预设菜单，而不是直接退出脚本。
- 区分参数模式和交互模式下的确认行为，同时保持现有参数模式的语义不变。
- 改进备份、还原和错误消息，使用更加清晰、描述性更强的双语输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add bilingual Chinese/English UI messaging to the PC registry modification script and refine interactive flows.

New Features:
- Display all interactive prompts, menus, and status messages in both Chinese and English in ModifyPCRegistry.ps1.

Enhancements:
- Adjust interactive preset selection so cancelling returns to the preset menu instead of exiting the script.
- Differentiate confirmation behavior between parameter mode and interactive mode while preserving existing parameter-mode semantics.
- Improve backup, restore, and error messages with clearer, more descriptive bilingual output.

</details>

</details>