### PR TITLE
fix(combat): handle automatically opened recovery page

### DIFF
--- a/agent/custom/action/combat.py
+++ b/agent/custom/action/combat.py
@@ -938,19 +938,24 @@ class SSReopenReplay(CustomAction):
         # 看看要不要吃不吃糖
         availability = _tc_get_availability(context)
         available_count = availability.available_count
-        if available_count is None:
-            logger.debug("识别战斗次数失败")
-            available_count = 1
-        elif available_count <= 0:
+        if availability.page is _TargetCountPage.UNKNOWN or available_count is None:
+            logger.error("无法识别关卡体力信息，停止重开关卡")
+            context.run_task("HomeButton")
+            context.tasker.post_stop()
+            return CustomAction.RunResult(success=False)
+
+        if available_count <= 0:
             logger.debug("没体力咯，吃个糖")
             for _ in range(2):  # 最多吃两次糖，防止吃mini糖体力不够
                 context.run_task("EatCandy")
 
                 availability = _tc_get_availability(context)
                 available_count = availability.available_count
-                if available_count is None:
-                    logger.debug("识别战斗次数失败")
-                    available_count = 1
+                if availability.page is _TargetCountPage.UNKNOWN or available_count is None:
+                    logger.error("补充体力后无法识别关卡体力信息，停止重开关卡")
+                    context.run_task("HomeButton")
+                    context.tasker.post_stop()
+                    return CustomAction.RunResult(success=False)
             if available_count <= 0:
                 logger.debug("尝试吃糖后体力不够，任务结束。")
                 context.run_task("HomeButton")

--- a/agent/custom/action/combat.py
+++ b/agent/custom/action/combat.py
@@ -1,5 +1,7 @@
 import re
 import time
+from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Any
 
 from maa.agent.agent_server import AgentServer
@@ -639,36 +641,79 @@ class _TargetCountState:
     candy_attempts: int = 0
 
 
-def _tc_safe_int(text: str) -> int:
+class _TargetCountPage(Enum):
+    STAGE = auto()
+    RECOVERY = auto()
+    UNKNOWN = auto()
+
+
+@dataclass(frozen=True)
+class _TargetCountAvailability:
+    page: _TargetCountPage
+    available_count: int | None = None
+
+
+def _tc_parse_int(text: str) -> int | None:
     try:
         return int(text)
-    except Exception:
-        return 0
+    except ValueError:
+        return None
 
 
-def _tc_get_text_safe(context: Context, img: Any, rec_name: str) -> str:
+def _tc_get_int(context: Context, img: Any, rec_name: str) -> int | None:
     rec = context.run_recognition(rec_name, img)
     text = ocr_text(rec)
     if not text:
-        logger.debug(f"{rec_name} 识别失败，返回None")
-        return "0"
-    return text
+        logger.debug(f"{rec_name} 识别失败")
+        return None
+
+    value = _tc_parse_int(text)
+    if value is None:
+        logger.debug(f"{rec_name} 识别结果不是有效整数: {text}")
+    return value
 
 
-def _tc_get_available_count(context: Context) -> int:
+def _tc_calculate_available_count(remaining_ap: int, stage_ap: int, combat_times: int) -> int | None:
+    if remaining_ap < 0 or stage_ap <= 0 or combat_times <= 0:
+        return None
+
+    stage_ap_per_combat, remainder = divmod(stage_ap, combat_times)
+    if stage_ap_per_combat <= 0 or remainder != 0:
+        return None
+
+    return remaining_ap // stage_ap_per_combat
+
+
+def _tc_get_availability(context: Context) -> _TargetCountAvailability:
     img = context.tasker.controller.post_screencap().wait().get()
-    remaining_ap = _tc_safe_int(_tc_get_text_safe(context, img, "RecognizeRemainingAp"))
-    stage_ap = _tc_safe_int(_tc_get_text_safe(context, img, "RecognizeStageAp"))
-    combat_times = _tc_safe_int(_tc_get_text_safe(context, img, "RecognizeCombatTimes"))
-    if stage_ap == 0:
-        logger.debug("stage_ap 为0")
-        return 999
-    if combat_times == 0:
-        logger.debug("识别失败，combat_times 为0")
-        return -1
-    stage_ap = stage_ap // combat_times
-    logger.debug(f"剩余体力: {remaining_ap}, 关卡体力: {stage_ap}")
-    return remaining_ap // stage_ap if stage_ap else 0
+    if is_hit(context.run_recognition("EatCandyPage", img)):
+        logger.debug("检测到活性恢复页，当前无可复现次数")
+        return _TargetCountAvailability(page=_TargetCountPage.RECOVERY, available_count=0)
+
+    remaining_ap = _tc_get_int(context, img, "RecognizeRemainingAp")
+    stage_ap = _tc_get_int(context, img, "RecognizeStageAp")
+    combat_times = _tc_get_int(context, img, "RecognizeCombatTimes")
+    if remaining_ap is None or stage_ap is None or combat_times is None:
+        logger.error(
+            "无法识别关卡体力信息: remaining_ap={}, stage_ap={}, combat_times={}",
+            remaining_ap,
+            stage_ap,
+            combat_times,
+        )
+        return _TargetCountAvailability(page=_TargetCountPage.UNKNOWN)
+
+    available_count = _tc_calculate_available_count(remaining_ap, stage_ap, combat_times)
+    if available_count is None:
+        logger.error(
+            "关卡体力信息无效: remaining_ap={}, stage_ap={}, combat_times={}",
+            remaining_ap,
+            stage_ap,
+            combat_times,
+        )
+        return _TargetCountAvailability(page=_TargetCountPage.UNKNOWN)
+
+    logger.debug(f"剩余体力: {remaining_ap}, 关卡体力: {stage_ap // combat_times}")
+    return _TargetCountAvailability(page=_TargetCountPage.STAGE, available_count=available_count)
 
 
 def _tc_pick_times(available_count: int, target_count: int, already_count: int) -> int:
@@ -722,10 +767,11 @@ class TargetCountDetermine(CustomAction):
             context.override_next("TargetCountDetermine", ["TargetCountFinish"])
             return CustomAction.RunResult(success=True)
 
-        available_count = _tc_get_available_count(context)
-        if available_count == -1:
+        availability = _tc_get_availability(context)
+        if availability.page is _TargetCountPage.UNKNOWN or availability.available_count is None:
             context.override_next("TargetCountDetermine", ["TargetCountAbort"])
             return CustomAction.RunResult(success=True)
+        available_count = availability.available_count
 
         times = _tc_pick_times(
             available_count,
@@ -768,7 +814,7 @@ class TargetCountSelectTimes(CustomAction):
             return CustomAction.RunResult(success=True)
 
         logger.info(f"选择复现 {times} 次")
-        context.run_task(
+        task_detail = context.run_task(
             "SetReplaysTimes",
             {
                 "SetReplaysTimes": {
@@ -780,6 +826,9 @@ class TargetCountSelectTimes(CustomAction):
                 }
             },
         )
+        if task_detail is None or task_detail.status.failed:
+            logger.error(f"选择复现 {times} 次失败，终止任务")
+            context.override_next("TargetCountSelectTimes", ["TargetCountAbort"])
         return CustomAction.RunResult(success=True)
 
 
@@ -795,8 +844,12 @@ class TargetCountEatCandy(CustomAction):
         argv: CustomAction.RunArg,
     ) -> CustomAction.RunResult:
 
-        context.run_task("EatCandy")
-        context.override_next("TargetCountEatCandy", ["TargetCountDetermine"])
+        task_detail = context.run_task("EatCandy")
+        if task_detail is None or task_detail.status.failed:
+            logger.error("补充体力任务执行失败，终止任务")
+            context.override_next("TargetCountEatCandy", ["TargetCountAbort"])
+        else:
+            context.override_next("TargetCountEatCandy", ["TargetCountDetermine"])
         return CustomAction.RunResult(success=True)
 
 
@@ -883,8 +936,9 @@ class SSReopenReplay(CustomAction):
         context.run_task("SSToReplayIfCan")
 
         # 看看要不要吃不吃糖
-        available_count = _tc_get_available_count(context)
-        if available_count == -1:
+        availability = _tc_get_availability(context)
+        available_count = availability.available_count
+        if available_count is None:
             logger.debug("识别战斗次数失败")
             available_count = 1
         elif available_count <= 0:
@@ -892,8 +946,9 @@ class SSReopenReplay(CustomAction):
             for _ in range(2):  # 最多吃两次糖，防止吃mini糖体力不够
                 context.run_task("EatCandy")
 
-                available_count = _tc_get_available_count(context)
-                if available_count == -1:
+                availability = _tc_get_availability(context)
+                available_count = availability.available_count
+                if available_count is None:
                     logger.debug("识别战斗次数失败")
                     available_count = 1
             if available_count <= 0:

--- a/agent/custom/action/combat.py
+++ b/agent/custom/action/combat.py
@@ -947,7 +947,12 @@ class SSReopenReplay(CustomAction):
         if available_count <= 0:
             logger.debug("没体力咯，吃个糖")
             for _ in range(2):  # 最多吃两次糖，防止吃mini糖体力不够
-                context.run_task("EatCandy")
+                task_detail = context.run_task("EatCandy")
+                if task_detail is None or task_detail.status.failed:
+                    logger.error("补充体力任务执行失败，停止重开关卡")
+                    context.run_task("HomeButton")
+                    context.tasker.post_stop()
+                    return CustomAction.RunResult(success=False)
 
                 availability = _tc_get_availability(context)
                 available_count = availability.available_count
@@ -956,6 +961,9 @@ class SSReopenReplay(CustomAction):
                     context.run_task("HomeButton")
                     context.tasker.post_stop()
                     return CustomAction.RunResult(success=False)
+
+                if available_count > 0:
+                    break
             if available_count <= 0:
                 logger.debug("尝试吃糖后体力不够，任务结束。")
                 context.run_task("HomeButton")

--- a/resource/base/pipeline/eat_candy.json
+++ b/resource/base/pipeline/eat_candy.json
@@ -1,6 +1,7 @@
 {
     "EatCandy": {
         "next": [
+            "EatCandyPage",
             "EatCandyEnter"
         ]
     },

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -70,16 +70,28 @@ class _ActionContext:
 
 
 class _SSActionContext:
-    def __init__(self) -> None:
+    def __init__(self, eat_candy_failed: bool | None = False) -> None:
         self.tasks: list[str] = []
         self.stopped = False
+        self.eat_candy_failed = eat_candy_failed
+        self.pipeline_overridden = False
         self.tasker = SimpleNamespace(
             controller=SimpleNamespace(cached_image=object()),
             post_stop=self._post_stop,
         )
 
-    def run_task(self, name: str, *_args: object, **_kwargs: object) -> None:
+    def run_task(self, name: str, *_args: object, **_kwargs: object) -> object | None:
         self.tasks.append(name)
+        if name == "EatCandy" and self.eat_candy_failed is None:
+            return None
+        failed = self.eat_candy_failed if name == "EatCandy" else False
+        return SimpleNamespace(status=SimpleNamespace(failed=failed))
+
+    def run_recognition(self, _name: str, _image: object) -> None:
+        return None
+
+    def override_pipeline(self, _pipeline: object) -> None:
+        self.pipeline_overridden = True
 
     def _post_stop(self) -> None:
         self.stopped = True
@@ -179,6 +191,40 @@ def test_ss_reopen_stops_when_availability_is_unknown_after_eating_candy(monkeyp
         ]
     )
     monkeypatch.setattr(combat_module, "_tc_get_availability", lambda _context: next(availabilities))
+
+    result = SSReopenReplay().run(context, None)  # type: ignore[arg-type]
+
+    assert not result.success
+    assert context.tasks == ["SSToReplayIfCan", "EatCandy", "HomeButton"]
+    assert context.stopped
+
+
+def test_ss_reopen_stops_eating_after_first_successful_restoration(monkeypatch: pytest.MonkeyPatch) -> None:
+    context = _SSActionContext()
+    availabilities = iter(
+        [
+            combat_module._TargetCountAvailability(page=_TargetCountPage.RECOVERY, available_count=0),
+            combat_module._TargetCountAvailability(page=_TargetCountPage.STAGE, available_count=1),
+        ]
+    )
+    monkeypatch.setattr(combat_module, "_tc_get_availability", lambda _context: next(availabilities))
+
+    result = SSReopenReplay().run(context, None)  # type: ignore[arg-type]
+
+    assert result.success
+    assert context.tasks == ["SSToReplayIfCan", "EatCandy", "OpenReplaysTimes", "SSReopenBackToMain"]
+    assert context.pipeline_overridden
+    assert not context.stopped
+
+
+@pytest.mark.parametrize("eat_candy_failed", [None, True])
+def test_ss_reopen_stops_when_eat_candy_subtask_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    eat_candy_failed: bool | None,
+) -> None:
+    context = _SSActionContext(eat_candy_failed=eat_candy_failed)
+    recovery = combat_module._TargetCountAvailability(page=_TargetCountPage.RECOVERY, available_count=0)
+    monkeypatch.setattr(combat_module, "_tc_get_availability", lambda _context: recovery)
 
     result = SSReopenReplay().run(context, None)  # type: ignore[arg-type]
 

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -6,7 +6,9 @@ import numpy as np
 import pytest
 from maa.define import OCRResult, RecognitionDetail, RecognitionResult, Rect
 
+import agent.custom.action.combat as combat_module
 from agent.custom.action.combat import (
+    SSReopenReplay,
     TargetCountEatCandy,
     TargetCountSelectTimes,
     _TargetCountPage,
@@ -54,14 +56,33 @@ class _RecognitionContext:
 
 
 class _ActionContext:
-    def __init__(self) -> None:
+    def __init__(self, task_failed: bool | None = None) -> None:
         self.override: tuple[str, list[str]] | None = None
+        self.task_failed = task_failed
 
-    def run_task(self, *_args: object, **_kwargs: object) -> None:
-        return None
+    def run_task(self, *_args: object, **_kwargs: object) -> object | None:
+        if self.task_failed is None:
+            return None
+        return SimpleNamespace(status=SimpleNamespace(failed=self.task_failed))
 
     def override_next(self, node: str, next_nodes: list[str]) -> None:
         self.override = (node, next_nodes)
+
+
+class _SSActionContext:
+    def __init__(self) -> None:
+        self.tasks: list[str] = []
+        self.stopped = False
+        self.tasker = SimpleNamespace(
+            controller=SimpleNamespace(cached_image=object()),
+            post_stop=self._post_stop,
+        )
+
+    def run_task(self, name: str, *_args: object, **_kwargs: object) -> None:
+        self.tasks.append(name)
+
+    def _post_stop(self) -> None:
+        self.stopped = True
 
 
 def test_calculate_available_count_distinguishes_zero_and_invalid_values() -> None:
@@ -112,9 +133,55 @@ def test_select_times_aborts_when_subtask_fails(monkeypatch: pytest.MonkeyPatch)
     assert context.override == ("TargetCountSelectTimes", ["TargetCountAbort"])
 
 
+def test_select_times_keeps_normal_next_when_subtask_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    context = _ActionContext(task_failed=False)
+    monkeypatch.setattr(_TargetCountState, "current_times", 3)
+
+    TargetCountSelectTimes().run(context, None)  # type: ignore[arg-type]
+
+    assert context.override is None
+
+
 def test_eat_candy_aborts_when_subtask_fails() -> None:
     context = _ActionContext()
 
     TargetCountEatCandy().run(context, None)  # type: ignore[arg-type]
 
     assert context.override == ("TargetCountEatCandy", ["TargetCountAbort"])
+
+
+def test_eat_candy_returns_to_determine_when_subtask_succeeds() -> None:
+    context = _ActionContext(task_failed=False)
+
+    TargetCountEatCandy().run(context, None)  # type: ignore[arg-type]
+
+    assert context.override == ("TargetCountEatCandy", ["TargetCountDetermine"])
+
+
+def test_ss_reopen_stops_when_initial_availability_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    context = _SSActionContext()
+    unknown = combat_module._TargetCountAvailability(page=_TargetCountPage.UNKNOWN)
+    monkeypatch.setattr(combat_module, "_tc_get_availability", lambda _context: unknown)
+
+    result = SSReopenReplay().run(context, None)  # type: ignore[arg-type]
+
+    assert not result.success
+    assert context.tasks == ["SSToReplayIfCan", "HomeButton"]
+    assert context.stopped
+
+
+def test_ss_reopen_stops_when_availability_is_unknown_after_eating_candy(monkeypatch: pytest.MonkeyPatch) -> None:
+    context = _SSActionContext()
+    availabilities = iter(
+        [
+            combat_module._TargetCountAvailability(page=_TargetCountPage.RECOVERY, available_count=0),
+            combat_module._TargetCountAvailability(page=_TargetCountPage.UNKNOWN),
+        ]
+    )
+    monkeypatch.setattr(combat_module, "_tc_get_availability", lambda _context: next(availabilities))
+
+    result = SSReopenReplay().run(context, None)  # type: ignore[arg-type]
+
+    assert not result.success
+    assert context.tasks == ["SSToReplayIfCan", "EatCandy", "HomeButton"]
+    assert context.stopped

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from maa.define import OCRResult, RecognitionDetail, RecognitionResult, Rect
+
+from agent.custom.action.combat import (
+    TargetCountEatCandy,
+    TargetCountSelectTimes,
+    _TargetCountPage,
+    _TargetCountState,
+    _tc_calculate_available_count,
+    _tc_get_availability,
+)
+
+
+def _recognition_detail(text: str | None = None) -> RecognitionDetail:
+    rect = Rect(1, 1, 2, 2)
+    best_result: RecognitionResult | None = OCRResult(rect, 0.9, text) if text is not None else None
+    return RecognitionDetail(
+        reco_id=1,
+        name="TestRecognition",
+        algorithm="Test",
+        hit=True,
+        box=rect,
+        all_results=[best_result] if best_result is not None else [],
+        filtered_results=[best_result] if best_result is not None else [],
+        best_result=best_result,
+        raw_detail={},
+        raw_image=np.zeros((1, 1, 3), dtype=np.uint8),
+        draw_images=[],
+    )
+
+
+class _ScreenshotRequest:
+    def wait(self) -> "_ScreenshotRequest":
+        return self
+
+    def get(self) -> object:
+        return object()
+
+
+class _RecognitionContext:
+    def __init__(self, results: dict[str, RecognitionDetail | None]) -> None:
+        self.results = results
+        self.calls: list[str] = []
+        self.tasker = SimpleNamespace(controller=SimpleNamespace(post_screencap=lambda: _ScreenshotRequest()))
+
+    def run_recognition(self, name: str, _image: object) -> RecognitionDetail | None:
+        self.calls.append(name)
+        return self.results.get(name)
+
+
+class _ActionContext:
+    def __init__(self) -> None:
+        self.override: tuple[str, list[str]] | None = None
+
+    def run_task(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def override_next(self, node: str, next_nodes: list[str]) -> None:
+        self.override = (node, next_nodes)
+
+
+def test_calculate_available_count_distinguishes_zero_and_invalid_values() -> None:
+    assert _tc_calculate_available_count(60, 60, 3) == 3
+    assert _tc_calculate_available_count(0, 20, 1) == 0
+    assert _tc_calculate_available_count(60, 0, 1) is None
+    assert _tc_calculate_available_count(60, 60, 0) is None
+    assert _tc_calculate_available_count(60, 61, 3) is None
+
+
+def test_get_availability_recognizes_an_already_open_recovery_page() -> None:
+    context = _RecognitionContext({"EatCandyPage": _recognition_detail()})
+
+    availability = _tc_get_availability(context)  # type: ignore[arg-type]
+
+    assert availability.page is _TargetCountPage.RECOVERY
+    assert availability.available_count == 0
+    assert context.calls == ["EatCandyPage"]
+
+
+def test_get_availability_aborts_when_page_and_required_values_are_unknown() -> None:
+    context = _RecognitionContext(
+        {
+            "RecognizeRemainingAp": _recognition_detail("60"),
+            "RecognizeCombatTimes": _recognition_detail("3"),
+        }
+    )
+
+    availability = _tc_get_availability(context)  # type: ignore[arg-type]
+
+    assert availability.page is _TargetCountPage.UNKNOWN
+    assert availability.available_count is None
+
+
+def test_eat_candy_pipeline_accepts_open_page_before_stage_entry() -> None:
+    pipeline_path = Path(__file__).parents[1] / "resource" / "base" / "pipeline" / "eat_candy.json"
+    pipeline = json.loads(pipeline_path.read_text(encoding="utf-8"))
+
+    assert pipeline["EatCandy"]["next"] == ["EatCandyPage", "EatCandyEnter"]
+
+
+def test_select_times_aborts_when_subtask_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    context = _ActionContext()
+    monkeypatch.setattr(_TargetCountState, "current_times", 3)
+
+    TargetCountSelectTimes().run(context, None)  # type: ignore[arg-type]
+
+    assert context.override == ("TargetCountSelectTimes", ["TargetCountAbort"])
+
+
+def test_eat_candy_aborts_when_subtask_fails() -> None:
+    context = _ActionContext()
+
+    TargetCountEatCandy().run(context, None)  # type: ignore[arg-type]
+
+    assert context.override == ("TargetCountEatCandy", ["TargetCountAbort"])


### PR DESCRIPTION
## 关联 Issue / Related Issue

暂无公开 Issue。需求来自近期 Sentry `TargetCountStartReplay/recognition` 失败事件：一轮复现恰好耗尽体力后，游戏自动打开“活性恢复”页，原逻辑却把关卡体力 OCR 缺失解释为可复现次数 `999`，继续进入开始复现节点。

Sentry: https://m9a.sentry.io/issues/7657794666/

## 变更摘要 / Summary

- 将目标次数刷图的页面状态明确区分为关卡页、活性恢复页和未知页面，移除 `-1` / `999` 哨兵值。
- 当活性恢复页已经打开时直接进入补体流程；`EatCandy` 仍兼容从关卡页点击体力入口。
- 检查 `SetReplaysTimes` 和 `EatCandy` 子任务结果，失败时转入 `TargetCountAbort`，避免继续执行错误节点。
- 新增体力计算、恢复页入口和子任务失败分支的回归测试。

## 验证 / Validation

- [x] `pnpm check`：通过（Prettier、schema、全部 MaaFW controller/resource 完整性检查）。
- [x] `pnpm check:py`：通过（ruff、pyright strict、80 个 pytest 测试）。
- 实机/控制器：未额外进行实机回归；问题现场来自 M9A v4.6.0 Sentry 附件中的 GUI/Python 日志和失败截图。

## 影响范围 / Impact

- `AllIn` / 目标次数刷图流程。
- `TargetCountDetermine`、`TargetCountSelectTimes`、`TargetCountEatCandy` 自定义动作。
- 共用体力可用次数判断的 `SSReopenReplay`。
- `resource/base/pipeline/eat_candy.json` 的入口候选顺序。

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

复现流程：

1. 启用连续吃糖并执行目标次数刷图。
2. 某批复现结束后体力恰好归零，游戏自动打开“活性恢复”页。
3. 旧逻辑无法识别 `RecognizeStageAp`，将缺失值转换成 `0`，再将 `stage_ap == 0` 转换成可用次数 `999`。
4. 流程错误进入 `TargetCountStartReplay`，但当前页面不存在“复现”按钮，最终识别失败。

失败截图及对应 GUI/Python 日志保存在上述 Sentry 事件附件中。相关 pipeline：`resource/base/pipeline/all_in.json`、`resource/base/pipeline/eat_candy.json`。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [x] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.（仅修复错误分支，无需用户文档变更。）
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Summary by Sourcery

在目标次数战斗流程中，处理会自动打开恢复页面的阶段，并确保在体力相关子任务失败时中止整条流水线，而不是继续执行。

Bug Fixes:
- 正确检测并将已打开的体力恢复页面视为可重开次数为零，避免错误计数并进入无效的重开流程。
- 当目标次数选择和体力恢复步骤的底层子任务失败时中止这些步骤，防止战斗流水线在无效状态下继续执行。

Enhancements:
- 在目标次数可用性计算中，用明确的页面/可用性建模替代哨兵值，以区分有效的零次计数和识别失败。
- 在 SS 重开流程中复用改进后的体力可用性逻辑，以更好地处理识别错误和恢复状态。

Tests:
- 为体力可用性计算和页面检测添加单元测试，包括已打开恢复页面以及未知/无效识别结果的处理。
- 添加测试，验证吃糖流水线在恢复页面已打开时可以正常进入，并且在子任务失败时，目标次数选择次数和吃糖操作会正确中止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle stages that auto-open the recovery page in target-count combat flows and ensure failures in stamina-related subtasks abort the pipeline instead of continuing.

Bug Fixes:
- Correctly detect and treat an already-open stamina recovery page as having zero available replays to avoid miscounting and entering invalid replay flows.
- Abort target-count selection and stamina recovery steps when their underlying subtasks fail, preventing the combat pipeline from continuing in an invalid state.

Enhancements:
- Replace sentinel values in target-count availability computation with explicit page/availability modeling to distinguish valid zero counts from recognition failures.
- Reuse the improved stamina availability logic in the SS replay reopen flow to better handle recognition errors and recovery conditions.

Tests:
- Add unit tests for stamina availability calculation and page detection, including handling of already-open recovery pages and unknown/invalid recognition results.
- Add tests verifying the eat-candy pipeline accepts an open recovery page entry and that target-count select-times and eat-candy actions abort when subtasks fail.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化战斗目标次数识别，区分关卡页、补体力页和未知页面。
  - 增强 OCR 数字解析与可用次数计算，支持补充体力后重新识别。
  - 糖果流程新增页面识别步骤，提升流程衔接准确性。

- **问题修复**
  - 识别、计算或补体失败时及时终止任务，避免异常继续执行。
  - 修复复现次数选择及未知页面下流程未及时停止的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->