### PR TITLE
feat: OCR 模型升级到 PP-OCRv6 (small)

### DIFF
--- a/maa-project.json
+++ b/maa-project.json
@@ -58,10 +58,10 @@
     },
     "ocr": {
         "files": {
-            "README.md": "ppocr_v4/zh_cn/README.md",
-            "det.onnx": "ppocr_v4/zh_cn/det.onnx",
-            "keys.txt": "ppocr_v4/zh_cn/keys.txt",
-            "rec.onnx": "ppocr_v4/zh_cn/rec.onnx"
+            "README.md": "ppocr_v6/small/README.md",
+            "det.onnx": "ppocr_v6/small/det.onnx",
+            "keys.txt": "ppocr_v6/small/keys.txt",
+            "rec.onnx": "ppocr_v6/small/rec.onnx"
         },
         "source": "submodule",
         "submodulePath": "MaaCommonAssets/OCR"

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -5,7 +5,7 @@ project_root = Path(__file__).resolve().parent.parent
 
 
 def configure_ocr_model():
-    source = project_root / "MaaCommonAssets" / "OCR" / "ppocr_v4" / "zh_cn"
+    source = project_root / "MaaCommonAssets" / "OCR" / "ppocr_v6" / "small"
     target = project_root / "resource" / "base" / "model" / "ocr"
     print(f"Copying OCR models from {source} to {target}")
     shutil.copytree(source, target, dirs_exist_ok=True)


### PR DESCRIPTION
将 OCR 模型从 ppocr_v4 升级到 PP-OCRv6 全 small 配置:

- 更新 MaaCommonAssets 子模块到 dabcd4681(含 PP-OCRv6 medium/small/tiny 三档)
- `tools/configure.py`:复制源从 `ppocr_v4/zh_cn` 改为 `ppocr_v6/small`
- `maa-project.json` ocr.files:det/rec/keys/README 全部指向 `ppocr_v6/small`

模型大小:det.onnx 9.4M + rec.onnx 20M。

## Summary by Sourcery

在整个项目中，将捆绑的 OCR 模型配置从 `ppocr_v4 zh_cn` 升级为 `PP-OCRv6 small`。

新特性：
- 采用 `PP-OCRv6 small` OCR 模型作为默认捆绑的 OCR 配置。

优化改进：
- 更新 `MaaCommonAssets` 子模块和项目配置，使 OCR 资源和元数据指向 `PP-OCRv6 small` 模型集。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the bundled OCR model configuration to use PP-OCRv6 small instead of ppocr_v4 zh_cn across the project.

New Features:
- Adopt PP-OCRv6 small OCR models as the default bundled OCR configuration.

Enhancements:
- Update MaaCommonAssets submodule and project configuration to point OCR assets and metadata to the PP-OCRv6 small model set.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - OCR 资源已升级至 PaddleOCR v6 small 中文模型，更新相关检测、识别及密钥配置路径。
- **改进**
  - 同步更新公共资源组件，确保应用使用最新的 OCR 资源。
  - 优化模型资源配置与复制流程，提升资源部署的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->