### PR TITLE
fix: 兼容领取误识别为预取

### DIFF
--- a/resource/base/pipeline/awards.json
+++ b/resource/base/pipeline/awards.json
@@ -1015,6 +1015,10 @@
                                     [
                                         "职",
                                         "取"
+                                    ],
+                                    [
+                                        "预",
+                                        "领"
                                     ]
                                 ],
                                 "color_filter": "AwardBreakingSignalsAward_color_filter"
@@ -1036,6 +1040,10 @@
                                     [
                                         "职",
                                         "取"
+                                    ],
+                                    [
+                                        "预",
+                                        "领"
                                     ]
                                 ]
                             }


### PR DESCRIPTION
## 关联 Issue / Related Issue

无。需求来源：用户运行日志（`maafw_logs_20260815_094925`）中每日任务「领取奖励」在「崭新的电波」活动领取签到奖励环节失败。

## 变更摘要 / Summary

- `AwardBreakingSignalsAward` 节点的两个 OCR 子识别（右上金色按钮 ROI `[946,12,294,78]`、底部 ROI `[792,586,381,67]`）的 `replace` 表新增 `["预", "领"]`
- 实测日志中事件页金色「领取」按钮被 OCR 稳定误读为「预取」（「领」「预」同含「页」旁，小字号 + 金色 `color_filter` 下字形混淆），替换后即可命中 `expected: "领取"`
- 与既有 `职→取` 修复（6fa9a0f6）机制同构，仅补充本次日志实测的新误读变体

## 验证 / Validation

- [x] `pnpm check`：Prettier → schema 校验 → MaaFW integrity 全部通过（exit 0）。仅存既有「未知任务 EventName」警告（与 HEAD 原样一致，与本次改动无关）
- 日志证据（`log/maafw.log`，09:39:00.9 ~ 09:39:20.9 共 21 次尝试 / 20s 超时）：
  - 每次右上 ROI 均稳定读到 `text="预取" score=0.650137`（box `[1178,41,35,18]`），`filtered_results_=[]`
  - `param_.expected=["领取"]` 从未命中 → `Node.NextList.Failed` → 任务失败
- 设备端真机未复测（需合入后经资源热更新验证）

## 影响范围 / Impact

- 仅 `resource/base/pipeline/awards.json` 的 `AwardBreakingSignalsAward` 节点（对应 `tasks/Awards.json`「崭新的电波」开关流程）
- 不影响其他任务、资源包顺序或发布流程

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

日志关键片段：

```
09:38:58.973 reco hit [result.name=AwardBreakingSignals] [result.box=[42,155,108,24]]  # 命中活动入口并点击
09:39:00.904 OCR [all_results_=[{"box":[1178,41,35,18],"score":0.650137,"text":"预取"}]] [param_.expected=["领取"]] [filtered_results_=[]]
09:39:00.949 Or recognition failed [name=AwardBreakingSignalsAward]
09:39:20.902 任务失败: 领取奖励
```

修复后 OCR 后处理链路：`预取` → replace(`预`→`领`) → `领取` → 命中 `expected`，随后点击按钮（Click 落在按钮中心）。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [ ] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Summary by Sourcery

提高“崭新的电波”每日奖励任务的 OCR 鲁棒性，防止将领取按钮误识别，从而导致任务失败。

Bug Fixes:
- 在 AwardBreakingSignalsAward 节点中处理将“领取”按钮误读为“预取”的情况，确保每日奖励领取流程能够稳定成功。

Enhancements:
- 扩展 AwardBreakingSignalsAward 的 OCR 后处理替换表，以覆盖奖励流程中右上角和底部按钮区域的更多误识别变体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve OCR robustness for the "崭新的电波" daily award task to prevent misrecognition of the领取按钮 causing task failures.

Bug Fixes:
- Handle OCR misreading of the "领取" button as "预取" in the AwardBreakingSignalsAward node so the daily reward claim flow succeeds consistently.

Enhancements:
- Extend the AwardBreakingSignalsAward OCR post-processing replace table to cover additional misrecognition variants for the top-right and bottom button regions in the awards pipeline.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化相关 OCR 识别规则，提升“领取”按钮的识别准确性。
  - 修复部分识别结果出现“职取”或“预领”时无法正确识别的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->