### PR TITLE
feat: 新增缪斯碰碰盒速刷任务

### DIFF
--- a/interface.json
+++ b/interface.json
@@ -195,6 +195,7 @@
         "tasks/UTTU.json",
         "tasks/CompleteInduction.json",
         "tasks/8bit.json",
+        "tasks/MusesBox.json",
         "tasks/CharUpgrade.json",
         "tasks/TrustReward.json",
         "tasks/WarehouseInventory.json"

--- a/resource/base/pipeline/activity/MusesBox.json
+++ b/resource/base/pipeline/activity/MusesBox.json
@@ -1,5 +1,5 @@
 {
-    "MusesBoxStratParty": {
+    "MusesBoxStartParty": {
         "desc": "缪斯碰碰盒点击派对启程",
         "recognition": {
             "type": "OCR",
@@ -21,7 +21,7 @@
         "timeout": 600000,
         "next": [
             "MusesBoxSettlement",
-            "MusesBoxStratParty" //兜底
+            "MusesBoxStartParty" //兜底
         ]
     },
     "MusesBoxSettlement": {
@@ -44,7 +44,7 @@
             "type": "Click"
         },
         "next": [
-            "MusesBoxStratParty",
+            "MusesBoxStartParty",
             "MusesBoxSettlement" //兜底
         ]
     }

--- a/resource/base/pipeline/activity/MusesBox.json
+++ b/resource/base/pipeline/activity/MusesBox.json
@@ -19,6 +19,7 @@
             "type": "Click"
         },
         "timeout": 600000,
+        "rate_limit": 5000,
         "next": [
             "MusesBoxSettlement",
             "MusesBoxStartParty" //兜底

--- a/resource/base/pipeline/activity/MusesBox.json
+++ b/resource/base/pipeline/activity/MusesBox.json
@@ -1,0 +1,51 @@
+{
+    "MusesBoxStratParty": {
+        "desc": "缪斯碰碰盒点击派对启程",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    985,
+                    595,
+                    295,
+                    70
+                ],
+                "expected": [
+                    ".*派对启程.*"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "timeout": 600000,
+        "next": [
+            "MusesBoxSettlement",
+            "MusesBoxStratParty" //兜底
+        ]
+    },
+    "MusesBoxSettlement": {
+        "desc": "缪斯碰碰盒结算",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    569,
+                    661,
+                    146,
+                    49
+                ],
+                "expected": [
+                    ".*点击空白退出.*"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "MusesBoxStratParty",
+            "MusesBoxSettlement" //兜底
+        ]
+    }
+}

--- a/tasks/MusesBox.json
+++ b/tasks/MusesBox.json
@@ -2,7 +2,7 @@
     "task": [
         {
             "name": "缪斯碰碰盒速刷",
-            "entry": "MusesBoxStratParty",
+            "entry": "MusesBoxStartParty",
             "group": [
                 "standalone"
             ],

--- a/tasks/MusesBox.json
+++ b/tasks/MusesBox.json
@@ -1,0 +1,12 @@
+{
+    "task": [
+        {
+            "name": "缪斯碰碰盒速刷",
+            "entry": "MusesBoxStratParty",
+            "group": [
+                "standalone"
+            ],
+            "description": "缪斯碰碰盒自动刷分<br><span style=\"color:tomato;font-size:15px\">请在右下角为「派对启程」的情况下运行该任务</span>"
+        }
+    ]
+}

--- a/tasks/preset/StandAlone.json
+++ b/tasks/preset/StandAlone.json
@@ -47,6 +47,10 @@
                 {
                     "name": "8-bit 街机秀",
                     "enabled": false
+                },
+                {
+                    "name": "缪斯碰碰盒速刷",
+                    "enabled": false
                 }
             ]
         }


### PR DESCRIPTION
# Pull Request

请保持变更范围聚焦，并填写适用的部分。

Please keep the change focused and fill in the sections that apply.

## 关联 Issue / Related Issue

无关联 Issue。需求来源：用户提出为「重返未来：1999」新活动小游戏「缪斯碰碰盒」实现自动刷分，参考仓库已有独立任务（如翻斗棋速刷）的结构实现。

## 变更摘要 / Summary

- 新增 Pipeline `resource/base/pipeline/activity/MusesBox.json`：`MusesBoxStratParty` 通过 OCR 识别右下角「派对启程」并点击进入；`MusesBoxSettlement` 识别「点击空白退出」后点击结算，循环刷分（两节点互为兜底）。
- 新增独立任务 `tasks/MusesBox.json`：「缪斯碰碰盒速刷」，入口 `MusesBoxStratParty`，归入 `standalone`（独立任务）分组，描述注明需在右下角显示「派对启程」时运行。
- `interface.json` 的 `import[]` 注册 `tasks/MusesBox.json`。
- `tasks/preset/StandAlone.json` 的「各种小游戏」预设登记新任务（默认不勾选）。

## 验证 / Validation

- `pnpm exec prettier --check .` — 通过（全仓库格式检查，改动文件均为 prettier 风格，无格式改动）。
- `node tools/validate-schema.mjs` — 通过：`[OK] local project schema is valid`（覆盖 interface.json 与 tasks/ 下全部任务文件）。
- 三个改动文件 JSON 语法解析 — 通过（`JSON.parse` 无错误）。
- `pnpm check` 中的 `check:maa`（`maa-tools check`）在本机**静默失败（exit 1，无输出）**：已做对照实验，`git stash` 暂存全部改动、甚至移走全部相关文件后的干净工作区同样失败，确认与本次改动无关，属本机环境无法初始化 MaaFW 运行时的问题，建议由 CI 执行该项。
- 未进行实机/模拟器运行验证：任务需在游戏内缪斯碰碰盒界面、右下角为「派对启程」时手动运行，暂无可用设备与截图。

- [ ] `pnpm check`

## 影响范围 / Impact

- 新增任务「缪斯碰碰盒速刷」（独立任务分组），仅影响新增的 `resource/base/pipeline/activity/MusesBox.json`、`tasks/MusesBox.json` 以及 `interface.json` 的 import 列表、`tasks/preset/StandAlone.json` 预设。
- 不触碰其他任务、pipeline、资源包（B 服/国际服等）、release workflow 或文档；无本地缓存、构建产物、调试文件或大文件。

## 截图 / 日志 / 说明 / Screenshots / Logs / Notes

- 纯 OCR 实现，无模板图片依赖，坐标基于 1280x720 基准：
  - `MusesBoxStratParty`：OCR ROI `[985, 595, 295, 70]`（右下角「派对启程」），`timeout: 600000`，next 为 `MusesBoxSettlement` + 自身兜底。
  - `MusesBoxSettlement`：OCR ROI `[569, 661, 146, 49]`（「点击空白退出」），next 为 `MusesBoxStratParty` + 自身兜底。
- 运行条件：进入缪斯碰碰盒界面，确认右下角显示「派对启程」后再启动任务（已写入任务描述）。
- `check:maa` 本地失败日志为空（见验证部分说明）。

## 检查清单 / Checklist

- [x] 我已阅读并遵守 `CONTRIBUTING.md` / I have read and followed `CONTRIBUTING.md`.
- [x] PR 范围清晰，没有混入无关格式化或重构 / The PR has one clear scope and does not include unrelated formatting or refactors.
- [x] 用户可见行为或流程变化已同步文档 / User-visible behavior or workflow changes are documented.（新任务的运行条件已写入任务 description；仓库 docs/ 无对应用户手册条目需更新）
- [x] 我没有提交本地缓存、构建产物、调试文件、下载的 runtime 文件或大体积模型文件 / I did not commit local caches, build outputs, debug files, downloaded runtime files, or large model files.

## Sourcery 总结

新增自动刷取缪斯碰碰盒活动，并通过独立任务目录提供该功能。

新功能：
- 新增基于 OCR 的自动化流程，用于自动启动并重复结算缪斯碰碰盒活动小游戏。
- 新增独立的“缪斯碰碰盒速刷”任务，并提供从活动界面启动该任务的使用说明。

增强：
- 在界面导入模块和独立小游戏预设中注册新任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automated Muses Box activity farming and expose it through the standalone task catalog.

New Features:
- Add an OCR-driven pipeline for automatically starting and repeatedly settling the Muses Box activity mini-game.
- Add the standalone “缪斯碰碰盒速刷” task with usage guidance for launching it from the activity screen.

Enhancements:
- Register the new task in the interface imports and the standalone mini-game preset.

</details>

新功能：
- 引入基于 OCR 的 MusesBox 流水线节点，用于自动开启活动并在重复刷分时处理结算流程。
- 新增「缪斯碰碰盒速刷」的独立任务定义，并附带合适的分组和运行时描述。

改进：
- 在界面导入和「各种小游戏」独立预设中注册新的 MusesBox 任务，使用户可以发现并启用该任务。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

新增自动刷取缪斯碰碰盒活动，并通过独立任务目录提供该功能。

新功能：
- 新增基于 OCR 的自动化流程，用于自动启动并重复结算缪斯碰碰盒活动小游戏。
- 新增独立的“缪斯碰碰盒速刷”任务，并提供从活动界面启动该任务的使用说明。

增强：
- 在界面导入模块和独立小游戏预设中注册新任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automated Muses Box activity farming and expose it through the standalone task catalog.

New Features:
- Add an OCR-driven pipeline for automatically starting and repeatedly settling the Muses Box activity mini-game.
- Add the standalone “缪斯碰碰盒速刷” task with usage guidance for launching it from the activity screen.

Enhancements:
- Register the new task in the interface imports and the standalone mini-game preset.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“缪斯碰碰盒速刷”任务，支持自动识别“派对启程”和“点击空白退出”等界面。
  * 自动执行进入、点击、结算及失败重试流程，并支持流程超时处理。
  * 新增任务入口、运行提示及流程配置。

* **配置**
  * 将该任务加入“各种小游戏”预设，默认处于禁用状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->