### PR TITLE
feat(tools): add MaaFW Sentry telemetry and cross-version trend analysis tools

### DIFF
--- a/.agents/skills/maafw-sentry-analysis/SKILL.md
+++ b/.agents/skills/maafw-sentry-analysis/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: maafw-sentry-analysis
+description: >-
+    Analyze Sentry telemetry data for MaaFramework (MaaFW) applications including
+    task failure rates, cross-version trend comparison, stability ranking, and regression detection.
+    Activate when the user asks about task failure rates, version comparisons, regression analysis,
+    or task stability inspection.
+---
+
+# MaaFramework Sentry 遥测数据分析指南
+
+本指南指导 AI Agent 如何调用 `tools.sentry.cli` 分析 MaaFramework（MaaFW）应用在生产环境中的任务失败率、跨版本走势及异常回归。
+
+> [!NOTE]
+> 运行本工具依赖新一代 Sentry CLI（[cli.sentry.dev](https://cli.sentry.dev/)，命令名为 `sentry`，可通过 `pnpm add -g sentry` 安装并通过 `sentry auth` 登录）。若未安装，先提示用户安装认证。
+
+---
+
+## 快速决策树（Scenario $\rightarrow$ Command）
+
+| 用户意图 / 场景                  | 推荐命令                                                                | 关注重点                                             |
+| :------------------------------- | :---------------------------------------------------------------------- | :--------------------------------------------------- |
+| **排查当前版本最不稳定的任务**   | `uv run python -m tools.sentry.cli task-failure --sort rate --limit 10` | 优先关注失败率排在最前的任务（Top 10）               |
+| **排查新版本是否发生负向回归**   | `uv run python -m tools.sentry.cli task-trend --sort delta --limit 10`  | 关注 `+X.Xpp` 涨幅最大的任务（即新版显著恶化的任务） |
+| **查看特定任务在各版本的表现**   | `uv run python -m tools.sentry.cli task-trend --task <任务名>`          | 查阅该任务在各历史版本下的样本总量、失败量与走势     |
+| **全局多版本大盘概览**           | `uv run python -m tools.sentry.cli task-trend --versions 3`             | 查阅高频主干任务在各版本间的失败率走势               |
+| **生成供汇报的 Markdown / JSON** | 追加 `--format markdown` 或 `--format json`                             | 便于直接嵌入工单、PR 或分析报表                      |
+
+---
+
+## 核心命令与常用参数
+
+统一通过 Python 模块入口运行：`uv run python -m tools.sentry.cli <子命令>`。
+
+### 1. `task-trend`（跨版本趋势与环比对比）
+
+- `--versions N`：对比最近 N 个版本（默认 `3`）。
+- `--sort {runs,rate,delta,name}`：
+    - `rate`：按最新版本失败率降序排列（找高危任务）；
+    - `delta`：按环比恶化幅度降序排列（找回归任务，`+12.7pp` > `+1.0pp` > `-2.0pp`）；
+    - `runs`：按运行量降序（默认）；
+    - `name`：按任务名字典序。
+- `--limit N`：限制输出行数（强烈建议配合 `--sort` 使用，如 `--limit 10`，避免大表溢出屏幕）。
+- `--reverse`：反转排序（如排查稳定性最高或改善最明显的任务）。
+- `--task <任务名>`：穿透查询单个任务（支持模糊匹配）。
+- `--include-beta`：在版本序列中包含 beta / rc 测试版（默认仅对比正式稳定版）。
+
+### 2. `task-failure`（单版本深度体检）
+
+- `--sort {failures,rate,total,name}`：
+    - `rate`：按失败率降序排列；
+    - `failures`：按失败绝对次数降序排列（默认）；
+    - `total`：按总运行次数降序；
+    - `name`：按任务名排序。
+- `--limit N`：同时限制「任务表」与「失败节点标记表」的最大展示行数。
+- `--release <release字符串>`：手动指定特定 release（未指定时自动通过 Sentry API 探索最新版本）。
+
+---
+
+## 数据解读与统计口径
+
+1. **唯一 Trace 去重**：
+   所有样本按 `count_unique(trace)` 聚合，一次管线运行内部多次触发同一事件不会被重复计数。
+2. **环比百分点（Δpp）**：
+    - 格式形如 `21.6% (+12.7pp)`：表示该版本失败率为 21.6%，相较于上一版本上升了 12.7 个百分点（恶化）；
+    - 格式形如 `3.9% (-2.0pp)`：表示相较于上一版本下降了 2.0 个百分点（优化改善）；
+    - `0.0pp`：表现持平。
+3. **任务 vs 失败节点标记**：
+    - **顶层任务**：具有成功（`ok`）样本或实际业务任务名，展示 `总次数 / 失败 / 取消 / 失败率`；
+    - **失败节点标记**：内部节点或系统事件（如 `控制器初始化失败`、`连接失败`、`ReturnMain`），仅在失败时上报，不具备成功样本，因此仅计触发次数，不参与失败率计算。
+
+---
+
+## 配置文件规范 (`tools/sentry/config.json`)
+
+工具从同级目录下的 `config.json` 加载配置，若文件不存在或缺少必填字段会直接抛出异常：
+
+```json
+{
+    "target": "m9a/gui",
+    "project_prefix": "m9a",
+    "release_pattern": null,
+    "task_run_spans": [
+        "mfa.task_run",
+        "mxu.task_run"
+    ],
+    "ignored_prefixes": ["__MXU"],
+    "ignored_suffixes": [".task_run"]
+}
+```
+
+当协助用户将本工具迁移到其他 MaaFW 项目（如 MaaEnd、MAA 等）时，只需告知用户修改上述 JSON 即可，无需改动任何 Python 源码。

--- a/tests/test_sentry_report.py
+++ b/tests/test_sentry_report.py
@@ -554,7 +554,7 @@ class TestConfig:
         with pytest.raises(ValueError, match="缺少必填字段"):
             load_config(bad_file)
 
-    def test_raises_when_collection_fields_not_string_list(self, tmp_path: Path) -> None:
+    def test_sentry_report_raises_when_collection_fields_not_string_list(self, tmp_path: Path) -> None:
         from tools.sentry.config import load_config
 
         # 字符串而非列表
@@ -569,7 +569,7 @@ class TestConfig:
         with pytest.raises(ValueError, match="列表项必须是字符串"):
             load_config(bad_items)
 
-    def test_validates_custom_release_pattern_group_count(self, tmp_path: Path) -> None:
+    def test_sentry_report_validates_custom_release_pattern_group_count(self, tmp_path: Path) -> None:
         from tools.sentry.config import load_config
 
         # 仅有 3 个组，不足 5 个
@@ -582,7 +582,7 @@ class TestConfig:
             load_config(bad_pattern)
 
         good_pattern = tmp_path / "good_pattern.json"
-        pattern_str = r"v(\d+)\.(\d+)\.(\d+)(-beta\.(\d+))?"
+        pattern_str = r"v(\d+)\.(\d+)\.(\d+)(?:-(beta|rc)\.(\d+))?"
         good_pattern.write_text(
             json.dumps({"target": "t", "project_prefix": "p", "release_pattern": pattern_str}),
             encoding="utf-8",
@@ -590,7 +590,7 @@ class TestConfig:
         cfg = load_config(good_pattern)
         assert cfg.release_pattern is not None
 
-    def test_generic_version_extraction_for_other_projects(self) -> None:
+    def test_sentry_report_generic_version_extraction_for_other_projects(self) -> None:
         import re
 
         # MaaEnd standard release: MaaEnd@v2.1.0-beta.2
@@ -609,7 +609,7 @@ class TestConfig:
 
 
 class TestTaskFailureEdgeCases:
-    def test_in_version_excludes_missing_or_null_release(self) -> None:
+    def test_sentry_report_in_version_excludes_missing_or_null_release(self) -> None:
         from tools.sentry.task_failure_report import _in_version
 
         key = (4, 7, 1, 2, 0)
@@ -620,7 +620,7 @@ class TestTaskFailureEdgeCases:
         # 未指定版本时，返回 True
         assert _in_version({"release": None}, None) is True
 
-    def test_build_release_rows_with_target_release(self) -> None:
+    def test_sentry_report_build_release_rows_with_target_release(self) -> None:
         from tools.sentry.task_failure_report import build_release_rows
 
         totals = [
@@ -638,7 +638,29 @@ class TestTaskFailureEdgeCases:
         assert rows[0].total == 100
         assert rows[0].failed == 10
 
-    def test_markers_sorting_respects_reverse(self) -> None:
+    def test_sentry_report_multi_channel_umbrella_aggregation_for_standard_version(self) -> None:
+        from tools.sentry.task_failure_report import build_release_rows
+
+        totals = [
+            {"release": "m9a@v4.7.1", "count_unique(trace)": 100},
+            {"release": "MXU@2.4.5+m9a@v4.7.1", "count_unique(trace)": 50},
+            {"release": "m9a@v4.7.0", "count_unique(trace)": 200},
+        ]
+        failures = [
+            {"release": "m9a@v4.7.1", "count_unique(trace)": 10},
+            {"release": "MXU@2.4.5+m9a@v4.7.1", "count_unique(trace)": 5},
+            {"release": "m9a@v4.7.0", "count_unique(trace)": 20},
+        ]
+        key = (4, 7, 1, 2, 0)
+        rows = build_release_rows(totals, failures, key)
+        # 同一版本的两个渠道均保留，排除不同版本
+        assert len(rows) == 2
+        release_names = {r.release for r in rows}
+        assert "m9a@v4.7.1" in release_names
+        assert "MXU@2.4.5+m9a@v4.7.1" in release_names
+        assert "m9a@v4.7.0" not in release_names
+
+    def test_sentry_report_markers_sorting_respects_reverse(self) -> None:
         from tools.sentry.task_failure_report import build_task_rows
 
         # 仅失败的节点标记
@@ -673,7 +695,7 @@ class TestTaskFailureEdgeCases:
 
 
 class TestTaskTrendEdgeCases:
-    def test_task_filter_exact_and_fuzzy_resolution(self) -> None:
+    def test_sentry_report_task_filter_exact_and_fuzzy_resolution(self) -> None:
         from tools.sentry.task_trend_report import build_trend_report
 
         totals = [
@@ -698,7 +720,7 @@ class TestTaskTrendEdgeCases:
         with pytest.raises(ValueError, match="匹配到多个候选任务"):
             build_trend_report(totals, statuses, ["v4.7.1"], task_filter="作战")
 
-    def test_baseline_only_task_not_in_displayed_rows(self) -> None:
+    def test_sentry_report_baseline_only_task_not_in_displayed_rows(self) -> None:
         from tools.sentry.task_trend_report import build_trend_report
 
         # 某个任务仅在最老基准版本 v4.6.1 中运行，但在展示版本 v4.7.1 中不存在

--- a/tests/test_sentry_report.py
+++ b/tests/test_sentry_report.py
@@ -1,4 +1,5 @@
 import io
+import json
 from pathlib import Path
 from typing import Any
 
@@ -553,6 +554,42 @@ class TestConfig:
         with pytest.raises(ValueError, match="缺少必填字段"):
             load_config(bad_file)
 
+    def test_raises_when_collection_fields_not_string_list(self, tmp_path: Path) -> None:
+        from tools.sentry.config import load_config
+
+        # 字符串而非列表
+        bad_str = tmp_path / "bad_str.json"
+        bad_str.write_text('{"target": "t", "project_prefix": "p", "task_run_spans": "not_a_list"}', encoding="utf-8")
+        with pytest.raises(ValueError, match="必须是字符串列表"):
+            load_config(bad_str)
+
+        # 列表中包含非字符串元素
+        bad_items = tmp_path / "bad_items.json"
+        bad_items.write_text('{"target": "t", "project_prefix": "p", "task_run_spans": [123]}', encoding="utf-8")
+        with pytest.raises(ValueError, match="列表项必须是字符串"):
+            load_config(bad_items)
+
+    def test_validates_custom_release_pattern_group_count(self, tmp_path: Path) -> None:
+        from tools.sentry.config import load_config
+
+        # 仅有 3 个组，不足 5 个
+        bad_pattern = tmp_path / "bad_pattern.json"
+        bad_pattern.write_text(
+            '{"target": "t", "project_prefix": "p", "release_pattern": "v(\\\\d+)\\\\.(\\\\d+)\\\\.(\\\\d+)"}',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="必须包含恰好 5 个捕获组"):
+            load_config(bad_pattern)
+
+        good_pattern = tmp_path / "good_pattern.json"
+        pattern_str = r"v(\d+)\.(\d+)\.(\d+)(-beta\.(\d+))?"
+        good_pattern.write_text(
+            json.dumps({"target": "t", "project_prefix": "p", "release_pattern": pattern_str}),
+            encoding="utf-8",
+        )
+        cfg = load_config(good_pattern)
+        assert cfg.release_pattern is not None
+
     def test_generic_version_extraction_for_other_projects(self) -> None:
         import re
 
@@ -569,3 +606,117 @@ class TestConfig:
         match_release = pattern.search("MaaEnd@v2.1.0")
         assert match_release is not None
         assert match_release.groups() == ("2", "1", "0", None, None)
+
+
+class TestTaskFailureEdgeCases:
+    def test_in_version_excludes_missing_or_null_release(self) -> None:
+        from tools.sentry.task_failure_report import _in_version
+
+        key = (4, 7, 1, 2, 0)
+        assert _in_version({"release": "m9a@v4.7.1"}, key) is True
+        assert _in_version({"release": "m9a@v4.7.0"}, key) is False
+        assert _in_version({"release": None}, key) is False
+        assert _in_version({}, key) is False
+        # 未指定版本时，返回 True
+        assert _in_version({"release": None}, None) is True
+
+    def test_build_release_rows_with_target_release(self) -> None:
+        from tools.sentry.task_failure_report import build_release_rows
+
+        totals = [
+            {"release": "custom_build_1", "count_unique(trace)": 100},
+            {"release": "other_build", "count_unique(trace)": 50},
+        ]
+        failures = [
+            {"release": "custom_build_1", "count_unique(trace)": 10},
+            {"release": "other_build", "count_unique(trace)": 5},
+        ]
+        # version_key is None (非标准 release), 指定 target_release 仅保留目标 release
+        rows = build_release_rows(totals, failures, None, target_release="custom_build_1")
+        assert len(rows) == 1
+        assert rows[0].release == "custom_build_1"
+        assert rows[0].total == 100
+        assert rows[0].failed == 10
+
+    def test_markers_sorting_respects_reverse(self) -> None:
+        from tools.sentry.task_failure_report import build_task_rows
+
+        # 仅失败的节点标记
+        totals = [
+            {"span.description": "MarkerA", "count_unique(trace)": 5, "release": "m9a@v4.7.1"},
+            {"span.description": "MarkerB", "count_unique(trace)": 15, "release": "m9a@v4.7.1"},
+        ]
+        statuses = [
+            {
+                "span.description": "MarkerA",
+                "span.status": "internal_error",
+                "count_unique(trace)": 5,
+                "release": "m9a@v4.7.1",
+            },
+            {
+                "span.description": "MarkerB",
+                "span.status": "internal_error",
+                "count_unique(trace)": 15,
+                "release": "m9a@v4.7.1",
+            },
+        ]
+        key = (4, 7, 1, 2, 0)
+        # reverse=False: 次数多的在前 (MarkerB: 15, MarkerA: 5)
+        _tasks, markers_desc = build_task_rows(totals, statuses, key, reverse=False)
+        assert markers_desc[0].task == "MarkerB"
+        assert markers_desc[1].task == "MarkerA"
+
+        # reverse=True: 次数少的在前 (MarkerA: 5, MarkerB: 15)
+        _tasks, markers_asc = build_task_rows(totals, statuses, key, reverse=True)
+        assert markers_asc[0].task == "MarkerA"
+        assert markers_asc[1].task == "MarkerB"
+
+
+class TestTaskTrendEdgeCases:
+    def test_task_filter_exact_and_fuzzy_resolution(self) -> None:
+        from tools.sentry.task_trend_report import build_trend_report
+
+        totals = [
+            {"release": "m9a@v4.7.1", "span.description": "常规作战", "count_unique(trace)": 20},
+            {"release": "m9a@v4.7.1", "span.description": "活动作战", "count_unique(trace)": 10},
+            {"release": "m9a@v4.7.1", "span.description": "每日任务", "count_unique(trace)": 15},
+        ]
+        statuses = [
+            {"release": "m9a@v4.7.1", "span.description": "常规作战", "span.status": "ok", "count_unique(trace)": 20},
+            {"release": "m9a@v4.7.1", "span.description": "活动作战", "span.status": "ok", "count_unique(trace)": 10},
+            {"release": "m9a@v4.7.1", "span.description": "每日任务", "span.status": "ok", "count_unique(trace)": 15},
+        ]
+        # 1. 唯一模糊匹配: "每日" -> "每日任务"
+        rep1 = build_trend_report(totals, statuses, ["v4.7.1"], task_filter="每日")
+        assert rep1.task_filter == "每日任务"
+
+        # 2. 完全精确匹配优先 (即便 "常规" 也能模糊匹配, 精确匹配仍生效)
+        rep2 = build_trend_report(totals, statuses, ["v4.7.1"], task_filter="常规作战")
+        assert rep2.task_filter == "常规作战"
+
+        # 3. 多个模糊匹配冲突 ("作战" 同时匹配到 "常规作战" 和 "活动作战")
+        with pytest.raises(ValueError, match="匹配到多个候选任务"):
+            build_trend_report(totals, statuses, ["v4.7.1"], task_filter="作战")
+
+    def test_baseline_only_task_not_in_displayed_rows(self) -> None:
+        from tools.sentry.task_trend_report import build_trend_report
+
+        # 某个任务仅在最老基准版本 v4.6.1 中运行，但在展示版本 v4.7.1 中不存在
+        totals = [
+            {"release": "m9a@v4.7.1", "span.description": "活跃任务", "count_unique(trace)": 30},
+            {"release": "m9a@v4.6.1", "span.description": "已废弃任务", "count_unique(trace)": 50},
+        ]
+        statuses = [
+            {"release": "m9a@v4.7.1", "span.description": "活跃任务", "span.status": "ok", "count_unique(trace)": 30},
+            {"release": "m9a@v4.6.1", "span.description": "已废弃任务", "span.status": "ok", "count_unique(trace)": 50},
+        ]
+        # 查询 2 个版本 (v4.7.1 与基准 v4.6.1)，但 display_versions 仅展示 ["v4.7.1"]
+        rep = build_trend_report(
+            totals,
+            statuses,
+            ["v4.7.1", "v4.6.1"],
+            display_versions=["v4.7.1"],
+        )
+        task_names = [row.task for row in rep.rows]
+        assert "活跃任务" in task_names
+        assert "已废弃任务" not in task_names

--- a/tests/test_sentry_report.py
+++ b/tests/test_sentry_report.py
@@ -25,6 +25,26 @@ class TestM9AReleaseVersionKey:
         assert report_common.m9a_release_version_key("MXU@2.4.5+m9a@v4.7.1+extra") is None
         assert report_common.m9a_release_version_key("MXU@2.4.5+m9a@abc") is None
 
+    def test_sentry_report_prerelease_rank_ordering(self) -> None:
+        key_alpha = (4, 7, 0, report_common.PRERELEASE_RANKS["alpha"], 1)
+        key_beta = (4, 7, 0, report_common.PRERELEASE_RANKS["beta"], 1)
+        key_rc = (4, 7, 0, report_common.PRERELEASE_RANKS["rc"], 1)
+        key_stable = (4, 7, 0, report_common.STABLE_RELEASE_RANK, 0)
+        assert key_alpha < key_beta < key_rc < key_stable
+
+    def test_sentry_report_rejects_unknown_prerelease_tag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import re
+
+        custom_pattern = re.compile(r"m9a@v(\d+)\.(\d+)\.(\d+)(?:-([a-z]+)\.(\d+))?")
+        monkeypatch.setattr(report_common, "RELEASE_PATTERN", custom_pattern)
+        # 支持的预发布标签
+        assert report_common.release_version_key("m9a@v4.7.1-beta.2") == (4, 7, 1, 0, 2)
+        assert report_common.release_version_key("m9a@v4.7.1-rc.1") == (4, 7, 1, 1, 1)
+        assert report_common.release_version_key("m9a@v4.7.1-alpha.3") == (4, 7, 1, -1, 3)
+        # 未知标签不应静默获得 beta 的 rank 0，必须返回 None
+        assert report_common.release_version_key("m9a@v4.7.1-preview.1") is None
+        assert report_common.release_version_key("m9a@v4.7.1-dev.5") is None
+
 
 class TestSelectLatestReportedRelease:
     def test_requires_finalized_release_with_deploy(self) -> None:

--- a/tests/test_sentry_report.py
+++ b/tests/test_sentry_report.py
@@ -1,0 +1,571 @@
+import io
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.sentry import cli, report_common, task_failure_report, task_trend_report
+
+
+def span_row(**values: Any) -> dict[str, Any]:
+    return values
+
+
+class TestM9AReleaseVersionKey:
+    def test_parses_embedded_stable_version(self) -> None:
+        assert report_common.m9a_release_version_key("MXU@2.4.5+m9a@v4.7.1") == (4, 7, 1, 2, 0)
+        assert report_common.m9a_release_version_key("m9a@v4.7.1") == (4, 7, 1, 2, 0)
+
+    def test_parses_embedded_beta_version(self) -> None:
+        assert report_common.m9a_release_version_key("MFA@v2.16.1-beta.3+m9a@v4.7.0-beta.1") == (4, 7, 0, 0, 1)
+
+    def test_rejects_release_without_m9a_suffix(self) -> None:
+        assert report_common.m9a_release_version_key("MXU@2.4.5") is None
+        assert report_common.m9a_release_version_key("MXU@2.4.5+m9a@v4.7.1+extra") is None
+        assert report_common.m9a_release_version_key("MXU@2.4.5+m9a@abc") is None
+
+
+class TestSelectLatestReportedRelease:
+    def test_requires_finalized_release_with_deploy(self) -> None:
+        rows = [
+            {
+                "version": "MXU@2.4.5+m9a@v4.7.1",
+                "dateReleased": "2026-09-01T00:00:00Z",
+                "deployCount": 0,
+            },
+            {
+                "version": "MFA@v2.16.0+m9a@v4.7.0",
+                "dateReleased": "2026-08-27T10:30:34Z",
+                "deployCount": 1,
+            },
+        ]
+        assert report_common.select_latest_reported_m9a_release(rows) == "MFA@v2.16.0+m9a@v4.7.0"
+
+    def test_returns_none_without_qualifying_release(self) -> None:
+        rows: list[dict[str, Any]] = [
+            {"version": "MXU@2.4.5+m9a@v4.7.1", "dateReleased": None, "deployCount": 0},
+            {"version": "MXU@2.4.2+m9a@v4.7.0", "dateCreated": "2026-08-30T13:00:00Z"},
+        ]
+        assert report_common.select_latest_reported_m9a_release(rows) is None
+
+
+class TestSelectLatestSpansRelease:
+    def test_picks_highest_version_above_user_threshold(self) -> None:
+        rows = [
+            span_row(release="MFA@v2.16.0+m9a@v4.7.0", **{"count_unique(user)": 500, "count_unique(trace)": 900}),
+            span_row(release="MXU@2.4.5+m9a@v4.7.1", **{"count_unique(user)": 20, "count_unique(trace)": 30}),
+            span_row(release="MXU@0.1.0+m9a@v4.7.1", **{"count_unique(user)": 3, "count_unique(trace)": 5}),
+            span_row(release="MXU@2.4.2", **{"count_unique(user)": 800, "count_unique(trace)": 900}),
+        ]
+        assert report_common.select_latest_m9a_release(rows) == "MXU@2.4.5+m9a@v4.7.1"
+
+    def test_raises_when_no_release_meets_threshold(self) -> None:
+        rows = [span_row(release="MXU@2.4.5+m9a@v4.7.1", **{"count_unique(user)": 3, "count_unique(trace)": 5})]
+        with pytest.raises(RuntimeError, match="显式指定"):
+            report_common.select_latest_m9a_release(rows)
+
+
+class TestBuildTaskRows:
+    def test_aggregates_status_columns_and_sorts_by_failures(self) -> None:
+        totals = [
+            span_row(**{"span.description": "领取奖励", "count_unique(trace)": 100}),
+            span_row(**{"span.description": "mfa.task_run", "count_unique(trace)": 200}),
+        ]
+        statuses = [
+            span_row(**{"span.description": "领取奖励", "span.status": "ok", "count_unique(trace)": 90}),
+            span_row(**{"span.description": "领取奖励", "span.status": "internal_error", "count_unique(trace)": 7}),
+            span_row(**{"span.description": "领取奖励", "span.status": "cancelled", "count_unique(trace)": 3}),
+            span_row(**{"span.description": "mfa.task_run", "span.status": "ok", "count_unique(trace)": 180}),
+            span_row(
+                **{"span.description": "mfa.task_run", "span.status": "internal_error", "count_unique(trace)": 20}
+            ),
+        ]
+        rows, markers = task_failure_report.build_task_rows(totals, statuses, None)
+        assert [(row.task, row.total, row.failed, row.cancelled) for row in rows] == [
+            ("mfa.task_run", 200, 20, 0),
+            ("领取奖励", 100, 7, 3),
+        ]
+        assert markers == []
+        assert rows[0].failure_rate == pytest.approx(0.1)
+        assert rows[1].failure_rate == pytest.approx(0.07)
+
+    def test_status_counts_stay_separate_per_status(self) -> None:
+        totals = [span_row(**{"span.description": "收取荒原", "count_unique(trace)": 10})]
+        statuses = [
+            span_row(**{"span.description": "收取荒原", "span.status": "ok", "count_unique(trace)": 9}),
+            span_row(**{"span.description": "收取荒原", "span.status": "internal_error", "count_unique(trace)": 2}),
+        ]
+        rows, markers = task_failure_report.build_task_rows(totals, statuses, None)
+        assert rows[0].total == 10
+        assert rows[0].failed == 2
+        assert rows[0].failure_rate == pytest.approx(0.2)
+        assert markers == []
+
+    def test_failure_only_descriptions_become_markers(self) -> None:
+        totals = [
+            span_row(**{"span.description": "领取奖励", "count_unique(trace)": 100}),
+            span_row(**{"span.description": "ReturnMain", "count_unique(trace)": 131}),
+            span_row(**{"span.description": "controller_initialization_failed", "count_unique(trace)": 2231}),
+        ]
+        statuses = [
+            span_row(**{"span.description": "领取奖励", "span.status": "ok", "count_unique(trace)": 95}),
+            span_row(**{"span.description": "领取奖励", "span.status": "internal_error", "count_unique(trace)": 5}),
+            span_row(**{"span.description": "ReturnMain", "span.status": "internal_error", "count_unique(trace)": 131}),
+            span_row(
+                **{
+                    "span.description": "controller_initialization_failed",
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 2231,
+                }
+            ),
+        ]
+        rows, markers = task_failure_report.build_task_rows(totals, statuses, None)
+        assert [row.task for row in rows] == ["领取奖励"]
+        assert [(row.task, row.total) for row in markers] == [
+            ("controller_initialization_failed", 2231),
+            ("ReturnMain", 131),
+        ]
+
+    def test_aggregates_across_channel_releases_for_same_version(self) -> None:
+        mfa = "MFA@v2.16.1-beta.3+m9a@v4.7.1"
+        mxu = "MXU@2.4.5+m9a@v4.7.1"
+        totals = [
+            span_row(**{"span.description": "领取奖励", "release": mfa, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "领取奖励", "release": mxu, "count_unique(trace)": 50}),
+            span_row(
+                **{"span.description": "领取奖励", "release": "MFA@v2.16.0+m9a@v4.7.0", "count_unique(trace)": 999}
+            ),
+        ]
+        statuses = [
+            span_row(
+                **{
+                    "span.description": "领取奖励",
+                    "release": mfa,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 5,
+                }
+            ),
+            span_row(
+                **{"span.description": "领取奖励", "release": mxu, "span.status": "ok", "count_unique(trace)": 45}
+            ),
+        ]
+        rows, _ = task_failure_report.build_task_rows(totals, statuses, (4, 7, 1, 2, 0))
+        assert rows[0].total == 150
+        assert rows[0].failed == 5
+        assert rows[0].failure_rate == pytest.approx(5 / 150)
+
+    def test_sorts_by_rate_and_respects_limit(self) -> None:
+        totals = [
+            span_row(**{"span.description": "LowRate", "count_unique(trace)": 100}),
+            span_row(**{"span.description": "HighRate", "count_unique(trace)": 100}),
+        ]
+        statuses = [
+            span_row(**{"span.description": "LowRate", "span.status": "internal_error", "count_unique(trace)": 5}),
+            span_row(**{"span.description": "LowRate", "span.status": "ok", "count_unique(trace)": 95}),
+            span_row(**{"span.description": "HighRate", "span.status": "internal_error", "count_unique(trace)": 30}),
+            span_row(**{"span.description": "HighRate", "span.status": "ok", "count_unique(trace)": 70}),
+        ]
+        tasks, _ = task_failure_report.build_task_rows(totals, statuses, None, sort="rate", limit=1)
+        assert len(tasks) == 1
+        assert tasks[0].task == "HighRate"
+        assert tasks[0].failure_rate == pytest.approx(0.3)
+
+
+class TestBuildReleaseRows:
+    def test_aggregates_by_release_string_and_sorts_by_total(self) -> None:
+        totals = [
+            span_row(release="MFA@v2.16.1-beta.3+m9a@v4.7.1", **{"count_unique(trace)": 500}),
+            span_row(release="MXU@2.4.5+m9a@v4.7.1", **{"count_unique(trace)": 200}),
+        ]
+        failures = [span_row(release="MXU@2.4.5+m9a@v4.7.1", **{"count_unique(trace)": 50})]
+        rows = task_failure_report.build_release_rows(totals, failures, (4, 7, 1, 2, 0))
+        assert [(row.release, row.total, row.failed) for row in rows] == [
+            ("MFA@v2.16.1-beta.3+m9a@v4.7.1", 500, 0),
+            ("MXU@2.4.5+m9a@v4.7.1", 200, 50),
+        ]
+        assert rows[1].failure_rate == pytest.approx(0.25)
+
+    def test_drops_releases_embedding_other_m9a_versions(self) -> None:
+        totals = [
+            span_row(release="MFA@v2.16.1-beta.3+m9a@v4.7.1", **{"count_unique(trace)": 500}),
+            span_row(release="MFA@v2.16.0+m9a@v4.7.0", **{"count_unique(trace)": 400}),
+            span_row(release="MXU@2.4.2", **{"count_unique(trace)": 300}),
+        ]
+        rows = task_failure_report.build_release_rows(totals, [], (4, 7, 1, 2, 0))
+        assert [row.release for row in rows] == ["MFA@v2.16.1-beta.3+m9a@v4.7.1"]
+
+    def test_keeps_all_releases_without_version_key(self) -> None:
+        totals = [
+            span_row(release="MFA@v2.16.1-beta.3+m9a@v4.7.1", **{"count_unique(trace)": 500}),
+            span_row(release="MFA@v2.16.0+m9a@v4.7.0", **{"count_unique(trace)": 400}),
+        ]
+        rows = task_failure_report.build_release_rows(totals, [], None)
+        assert len(rows) == 2
+
+
+class TestConsoleTable:
+    def test_aligns_cjk_wide_characters(self) -> None:
+        output = io.StringIO()
+        report_common.write_console_table(
+            ("任务/节点", "失败率"),
+            [("收取荒原", "5.0%"), ("StartUp", "21.4%")],
+            output,
+            right_aligned={1},
+        )
+        lines = output.getvalue().splitlines()
+        widths = {report_common.display_width(line) for line in lines}
+        assert len(widths) == 1
+        assert "│ 收取荒原" in lines[3]
+        assert "│   5.0%" in lines[3]
+
+
+class TestFormatRate:
+    def test_formats_percentages_and_missing_samples(self) -> None:
+        assert report_common.format_rate(0.052) == "5.2%"
+        assert report_common.format_rate(None) == "暂无样本"
+
+
+class TestCli:
+    def test_lists_task_failure_report(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert cli.main([]) == 0
+        out = capsys.readouterr().out
+        assert "task-failure" in out
+        assert "task-trend" in out
+
+    def test_rejects_unknown_report(self) -> None:
+        with pytest.raises(SystemExit):
+            cli.main(["no-such-report"])
+
+    def test_help_options(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert cli.main(["-h"]) == 0
+        out = capsys.readouterr().out
+        assert "usage: python -m tools.sentry.cli [-h]" in out
+        assert "task-failure" in out
+        assert "task-trend" in out
+
+        assert cli.main(["--help"]) == 0
+        assert "usage: python -m tools.sentry.cli [-h]" in capsys.readouterr().out
+
+
+class TestFormatRateWithDelta:
+    def test_formats_positive_delta(self) -> None:
+        assert task_trend_report.format_rate_with_delta(0.07, 1.4) == "7.0% (+1.4pp)"
+
+    def test_formats_negative_delta(self) -> None:
+        assert task_trend_report.format_rate_with_delta(0.056, -1.4) == "5.6% (-1.4pp)"
+
+    def test_formats_zero_delta(self) -> None:
+        assert task_trend_report.format_rate_with_delta(0.056, 0.0) == "5.6% (0.0pp)"
+
+    def test_formats_without_delta(self) -> None:
+        assert task_trend_report.format_rate_with_delta(0.056, None) == "5.6%"
+
+    def test_formats_missing_sample(self) -> None:
+        assert task_trend_report.format_rate_with_delta(None, None) == "暂无样本"
+
+
+class TestDiscoverVersions:
+    def test_filters_prerelease_by_default(self) -> None:
+        rows = [
+            span_row(release="MFA@v2.16.1-beta.3+m9a@v4.7.1", **{"count_unique(user)": 100}),
+            span_row(release="MFA@v2.16.0+m9a@v4.7.0-beta.1", **{"count_unique(user)": 50}),
+            span_row(release="MFA@v2.16.0+m9a@v4.7.0", **{"count_unique(user)": 80}),
+            span_row(release="MFA@v2.15.2+m9a@v4.6.2", **{"count_unique(user)": 90}),
+        ]
+        versions = task_trend_report.discover_versions(rows, count=2, include_prerelease=False)
+        assert versions == ["v4.7.1", "v4.7.0", "v4.6.2"]
+
+    def test_includes_prerelease_when_flag_set(self) -> None:
+        rows = [
+            span_row(release="MFA@v2.16.1-beta.3+m9a@v4.7.1", **{"count_unique(user)": 100}),
+            span_row(release="MFA@v2.16.0+m9a@v4.7.0-beta.1", **{"count_unique(user)": 50}),
+            span_row(release="MFA@v2.16.0+m9a@v4.7.0", **{"count_unique(user)": 80}),
+        ]
+        versions = task_trend_report.discover_versions(rows, count=2, include_prerelease=True)
+        assert versions == ["v4.7.1", "v4.7.0", "v4.7.0-beta.1"]
+
+
+class TestBuildTrendReport:
+    def test_calculates_cross_version_deltas(self) -> None:
+        mfa_v471 = "MFA@v2.16.1-beta.3+m9a@v4.7.1"
+        mxu_v471 = "MXU@2.4.5+m9a@v4.7.1"
+        mfa_v470 = "MFA@v2.16.0+m9a@v4.7.0"
+        mfa_v462 = "MFA@v2.15.2+m9a@v4.6.2"
+
+        totals = [
+            span_row(**{"span.description": "领取奖励", "release": mfa_v471, "count_unique(trace)": 60}),
+            span_row(**{"span.description": "领取奖励", "release": mxu_v471, "count_unique(trace)": 40}),
+            span_row(**{"span.description": "领取奖励", "release": mfa_v470, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "领取奖励", "release": mfa_v462, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "ReturnMain", "release": mfa_v471, "count_unique(trace)": 20}),
+        ]
+        statuses = [
+            span_row(
+                **{
+                    "span.description": "领取奖励",
+                    "release": mfa_v471,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 5,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "领取奖励",
+                    "release": mfa_v471,
+                    "span.status": "ok",
+                    "count_unique(trace)": 95,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "领取奖励",
+                    "release": mfa_v470,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 10,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "领取奖励",
+                    "release": mfa_v462,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 8,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "ReturnMain",
+                    "release": mfa_v471,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 20,
+                }
+            ),
+        ]
+
+        report = task_trend_report.build_trend_report(
+            totals,
+            statuses,
+            ["v4.7.1", "v4.7.0", "v4.6.2"],
+            min_latest_runs=10,
+        )
+        assert len(report.rows) == 1
+        row = report.rows[0]
+        assert row.task == "领取奖励"
+        assert row.latest_total == 100
+        assert row.version_rates["v4.7.1"] == pytest.approx(0.05)
+        assert row.version_rates["v4.7.0"] == pytest.approx(0.10)
+        assert row.version_rates["v4.6.2"] == pytest.approx(0.08)
+        assert row.version_deltas["v4.7.1"] == pytest.approx(-5.0)
+        assert row.version_deltas["v4.7.0"] == pytest.approx(2.0)
+        assert row.version_deltas["v4.6.2"] is None
+
+    def test_single_task_filter_builds_detailed_stats(self) -> None:
+        mfa_v471 = "MFA@v2.16.1-beta.3+m9a@v4.7.1"
+        mfa_v470 = "MFA@v2.16.0+m9a@v4.7.0"
+        totals = [
+            span_row(**{"span.description": "常规作战", "release": mfa_v471, "count_unique(trace)": 50}),
+            span_row(**{"span.description": "常规作战", "release": mfa_v470, "count_unique(trace)": 50}),
+        ]
+        statuses = [
+            span_row(
+                **{
+                    "span.description": "常规作战",
+                    "release": mfa_v471,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 10,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "常规作战",
+                    "release": mfa_v471,
+                    "span.status": "ok",
+                    "count_unique(trace)": 40,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "常规作战",
+                    "release": mfa_v470,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 5,
+                }
+            ),
+        ]
+        report = task_trend_report.build_trend_report(
+            totals,
+            statuses,
+            ["v4.7.1", "v4.7.0"],
+            task_filter="常规作战",
+        )
+        assert report.detailed_task_stats is not None
+        assert len(report.detailed_task_stats) == 2
+        assert report.detailed_task_stats[0].version == "v4.7.1"
+        assert report.detailed_task_stats[0].failure_rate == pytest.approx(0.2)
+        assert report.detailed_task_stats[0].delta_pp == pytest.approx(10.0)
+
+    def test_sorts_by_rate_and_respects_limit(self) -> None:
+        mfa_v471 = "MFA@v2.16.1-beta.3+m9a@v4.7.1"
+        mfa_v470 = "MFA@v2.16.0+m9a@v4.7.0"
+        totals = [
+            span_row(**{"span.description": "LowRate", "release": mfa_v471, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "LowRate", "release": mfa_v470, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "HighRate", "release": mfa_v471, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "HighRate", "release": mfa_v470, "count_unique(trace)": 100}),
+        ]
+        statuses = [
+            span_row(
+                **{
+                    "span.description": "LowRate",
+                    "release": mfa_v471,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 2,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "LowRate",
+                    "release": mfa_v471,
+                    "span.status": "ok",
+                    "count_unique(trace)": 98,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "HighRate",
+                    "release": mfa_v471,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 25,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "HighRate",
+                    "release": mfa_v471,
+                    "span.status": "ok",
+                    "count_unique(trace)": 75,
+                }
+            ),
+        ]
+        report = task_trend_report.build_trend_report(
+            totals,
+            statuses,
+            ["v4.7.1", "v4.7.0"],
+            sort="rate",
+            limit=1,
+        )
+        assert len(report.rows) == 1
+        assert report.rows[0].task == "HighRate"
+        assert report.rows[0].version_rates["v4.7.1"] == pytest.approx(0.25)
+
+    def test_sorts_by_delta_descending(self) -> None:
+        mfa_v471 = "MFA@v2.16.1-beta.3+m9a@v4.7.1"
+        mfa_v470 = "MFA@v2.16.0+m9a@v4.7.0"
+        totals = [
+            span_row(**{"span.description": "Improved", "release": mfa_v471, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "Improved", "release": mfa_v470, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "Regressed", "release": mfa_v471, "count_unique(trace)": 100}),
+            span_row(**{"span.description": "Regressed", "release": mfa_v470, "count_unique(trace)": 100}),
+        ]
+        statuses = [
+            span_row(
+                **{
+                    "span.description": "Improved",
+                    "release": mfa_v471,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 2,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "Improved",
+                    "release": mfa_v471,
+                    "span.status": "ok",
+                    "count_unique(trace)": 98,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "Improved",
+                    "release": mfa_v470,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 10,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "Regressed",
+                    "release": mfa_v471,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 20,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "Regressed",
+                    "release": mfa_v471,
+                    "span.status": "ok",
+                    "count_unique(trace)": 80,
+                }
+            ),
+            span_row(
+                **{
+                    "span.description": "Regressed",
+                    "release": mfa_v470,
+                    "span.status": "internal_error",
+                    "count_unique(trace)": 5,
+                }
+            ),
+        ]
+        report = task_trend_report.build_trend_report(
+            totals,
+            statuses,
+            ["v4.7.1", "v4.7.0"],
+            sort="delta",
+        )
+        assert len(report.rows) == 2
+        # Regressed: v4.7.1 (20%) - v4.7.0 (5%) = +15pp
+        # Improved: v4.7.1 (2%) - v4.7.0 (10%) = -8pp
+        assert report.rows[0].task == "Regressed"
+        assert report.rows[1].task == "Improved"
+
+
+class TestConfig:
+    def test_loads_config_from_json(self) -> None:
+        from tools.sentry.config import CONFIG
+
+        assert CONFIG.target == "m9a/gui"
+        assert CONFIG.project_prefix == "m9a"
+        assert "mfa.task_run" in CONFIG.task_run_spans
+
+    def test_raises_when_config_file_not_found(self, tmp_path: Path) -> None:
+        from tools.sentry.config import load_config
+
+        nonexistent = tmp_path / "missing.json"
+        with pytest.raises(FileNotFoundError):
+            load_config(nonexistent)
+
+    def test_raises_when_missing_required_fields(self, tmp_path: Path) -> None:
+        from tools.sentry.config import load_config
+
+        bad_file = tmp_path / "bad_config.json"
+        bad_file.write_text("{}", encoding="utf-8")
+        with pytest.raises(ValueError, match="缺少必填字段"):
+            load_config(bad_file)
+
+    def test_generic_version_extraction_for_other_projects(self) -> None:
+        import re
+
+        # MaaEnd standard release: MaaEnd@v2.1.0-beta.2
+        prefix = "MaaEnd"
+        pattern = re.compile(
+            rf"(?:^|[+/]){re.escape(prefix)}@v?(\d+)\.(\d+)\.(\d+)(?:-(beta|rc)\.(\d+))?$",
+            re.IGNORECASE,
+        )
+        match = pattern.search("MaaEnd@v2.1.0-beta.2")
+        assert match is not None
+        assert match.groups() == ("2", "1", "0", "beta", "2")
+
+        match_release = pattern.search("MaaEnd@v2.1.0")
+        assert match_release is not None
+        assert match_release.groups() == ("2", "1", "0", None, None)

--- a/tools/sentry/README.md
+++ b/tools/sentry/README.md
@@ -1,0 +1,206 @@
+# MaaFramework Sentry 遥测数据分析工具
+
+通用的 MaaFramework（MaaFW）应用 Sentry 性能与失败率分析套件。支持单版本任务深度体检、跨版本失败率趋势对比及环比变化量（Δpp）自动化计算。
+
+---
+
+## 目录
+
+- [前置要求](#前置要求)
+- [快速开始](#快速开始)
+- [命令详解](#命令详解)
+    - [1. 跨版本趋势报告 (task-trend)](#1-跨版本趋势报告-task-trend)
+    - [2. 单版本深度分析 (task-failure)](#2-单版本深度分析-task-failure)
+- [跨项目接入配置 (config.json)](#跨项目接入配置-configjson)
+- [统计口径说明](#统计口径说明)
+
+---
+
+## 前置要求
+
+本工具基于新一代面向开发者与 AI Agent 的 **Sentry CLI**（[cli.sentry.dev](https://cli.sentry.dev/)，命令名为 `sentry`，非旧版 `sentry-cli`）。
+
+1. **安装 Sentry CLI**（详见 [官方安装文档](https://cli.sentry.dev/getting-started/)）：
+    - **Node / 包管理器（跨平台 / Windows 推荐）**：
+        ```bash
+        pnpm add -g sentry
+        # 或
+        npm install -g sentry
+        ```
+    - **Linux / macOS 官方脚本**：
+        ```bash
+        curl https://cli.sentry.dev/install -fsS | bash
+        ```
+    - **Homebrew (macOS)**：
+        ```bash
+        brew install getsentry/tools/sentry
+        ```
+
+    _(使用 npm/pnpm 安装后可运行 `sentry cli setup` 启用自动补全与内置 Agent Skill)_
+
+2. **完成 Sentry 认证**（支持 OAuth Device Flow，免手动复制作业 Token）：
+    ```bash
+    sentry auth
+    ```
+    按提示在浏览器中确认授权即可。认证完成后可通过 `sentry auth status` 查看状态。
+
+---
+
+## 快速开始
+
+在项目根目录下通过 `python -m tools.sentry.cli` 运行：
+
+```bash
+# 1. 跨版本失败率走势（默认对比最近 3 个正式版）
+uv run python -m tools.sentry.cli task-trend
+
+# 2. 查看新版本中恶化最严重的 Top 10 任务（抓回归神器）
+uv run python -m tools.sentry.cli task-trend --sort delta --limit 10
+
+# 3. 查看最新版本中失败率最高的 Top 10 任务
+uv run python -m tools.sentry.cli task-failure --sort rate --limit 10
+```
+
+---
+
+## 命令详解
+
+### 1. 跨版本趋势报告 (`task-trend`)
+
+对比多个版本间任务的失败率变化，括号内标注相比上一版本的百分点环比变化量（如 `+12.7pp`、`-2.0pp`）。
+
+```bash
+uv run python -m tools.sentry.cli task-trend [选项]
+```
+
+**常用选项：**
+
+| 参数             | 说明                                                                                        | 示例                |
+| :--------------- | :------------------------------------------------------------------------------------------ | :------------------ |
+| `--versions N`   | 对比最近 N 个版本（默认: `3`）                                                              | `--versions 5`      |
+| `--sort`         | 排序维度：`runs`（总运行量，默认）、`rate`（失败率）、`delta`（恶化幅度）、`name`（任务名） | `--sort rate`       |
+| `--limit N`      | 限制输出的任务数量                                                                          | `--limit 10`        |
+| `--reverse`      | 反转排序（如升序看最稳定或改善最大的任务）                                                  | `--reverse`         |
+| `--task <名称>`  | 穿透单个任务查看其在各个版本下的明细记录                                                    | `--task 常规作战`   |
+| `--include-beta` | 包含 beta / rc 测试版（默认仅对比正式稳定版）                                               | `--include-beta`    |
+| `--format`       | 输出格式：`console`（默认）、`markdown`、`json`                                             | `--format markdown` |
+| `--period`       | 查询时间范围（默认: `90d`，确保覆盖多个版本）                                               | `--period 30d`      |
+
+#### 单任务穿透示例：
+
+```bash
+uv run python -m tools.sentry.cli task-trend --task 常规作战
+```
+
+输出：
+
+```text
+任务趋势明细: 常规作战
+┌────────┬────────┬────────┬────────┬──────────────┐
+│ 版本   │ 运行数 │ 失败数 │ 失败率 │ 相对上一版本 │
+├────────┼────────┼────────┼────────┼──────────────┤
+│ v4.7.1 │    712 │    154 │  21.6% │      +12.7pp │
+│ v4.7.0 │    258 │     23 │   8.9% │       -0.5pp │
+│ v4.6.2 │   1363 │    129 │   9.5% │       -9.1pp │
+└────────┴────────┴────────┴────────┴──────────────┘
+```
+
+---
+
+### 2. 单版本深度分析 (`task-failure`)
+
+针对指定或最新版本，全面分析任务成功/失败/取消分布、失败节点标记以及渠道 Umbrella Span 运行失败率。
+
+```bash
+uv run python -m tools.sentry.cli task-failure [选项]
+```
+
+**常用选项：**
+
+| 参数        | 说明                                                                            | 示例                     |
+| :---------- | :------------------------------------------------------------------------------ | :----------------------- |
+| `--release` | 指定分析的 Sentry release（未指定时自动选择最新版本）                           | `--release "m9a@v4.7.1"` |
+| `--sort`    | 排序规则：`failures`（失败数，默认）、`rate`（失败率）、`total`（总数）、`name` | `--sort rate`            |
+| `--limit N` | 限制任务表和失败标记表的最大展示行数                                            | `--limit 15`             |
+| `--reverse` | 反转排序                                                                        | `--reverse`              |
+| `--period`  | 查询时间范围（默认: `7d`）                                                      | `--period 14d`           |
+| `--format`  | 输出格式：`console`、`markdown`、`json`                                         | `--format json`          |
+
+---
+
+## 跨项目接入配置 (`config.json`)
+
+本工具已实现完全通用化。任何 MaaFW 应用项目只需在 `tools/sentry/config.json` 中配置自身项目的标识即可使用。
+
+> **注意**：脚本严格依赖 `config.json`；若未配置或缺少必填项，会直接抛出异常提示，不进行隐式硬编码回退。
+
+### 配置字段说明
+
+```json
+{
+    "target": "<sentry-org>/<sentry-project>",
+    "project_prefix": "<release-prefix>",
+    "release_pattern": null,
+    "task_run_spans": ["<span_name>"],
+    "ignored_prefixes": ["<prefix>"],
+    "ignored_suffixes": [".task_run"]
+}
+```
+
+- **`target`** _(必填)_：Sentry 的组织与项目标识，如 `"m9a/gui"` 或 `"maaend/maaend"`。
+- **`project_prefix`** _(必填)_：Release 版本前缀，系统会自动构造匹配 `prefix@vX.Y.Z`（含稳定版与测试版）的标准语义化正则。
+- **`release_pattern`** _(可选)_：自定义 Release 正则表达式。若项目采用非常规命名规范可填入，通常为 `null`。
+- **`task_run_spans`** _(可选)_：上报整次管线运行的根 Span（Umbrella span）名称列表。
+- **`ignored_prefixes`** _(可选)_：在大表中自动过滤的内部私有 Span 前缀。
+- **`ignored_suffixes`** _(可选)_：在大表中自动过滤的 Span 后缀。
+
+### 常用项目配置示例
+
+#### 1. M9A (`tools/sentry/config.json`)
+
+```json
+{
+    "target": "m9a/gui",
+    "project_prefix": "m9a",
+    "release_pattern": null,
+    "task_run_spans": [
+        "mfa.task_run",
+        "mxu.task_run"
+    ],
+    "ignored_prefixes": [
+        "__MXU"
+    ],
+    "ignored_suffixes": [
+        ".task_run"
+    ]
+}
+```
+
+#### 2. MaaEnd (`tools/sentry/config.json`)
+
+```json
+{
+    "target": "maaend/maaend",
+    "project_prefix": "MaaEnd",
+    "release_pattern": null,
+    "task_run_spans": [
+        "maaend.task_run"
+    ],
+    "ignored_prefixes": [],
+    "ignored_suffixes": [
+        ".task_run"
+    ]
+}
+```
+
+---
+
+## 统计口径说明
+
+1. **唯一 Trace 去重**：
+    - 报告中所有计数字段均按 `count_unique(trace)` 统计，同一用户或同一次管线运行内部多次触发同一事件不会被重复计数。
+2. **业务任务 vs 失败节点标记**：
+    - **业务任务**：具有成功（`ok`）样本或至少被用户执行过的顶层任务，计算真实的失败概率（`失败数 / 总数`）；
+    - **失败节点标记**：仅在失败时上报的内部标记（如系统级 `控制器初始化失败`、`连接失败` 或 pipeline 内部返回节点），没有成功样本，仅记录触发次数，不计入任务失败率计算。
+3. **环比变化量（Δpp）**：
+    - 标注格式为 `百分比 (Δ百分点)`，例如 `21.6% (+12.7pp)` 表示当前版本失败率为 21.6%，相比上一版本上升了 12.7 个百分点。

--- a/tools/sentry/__init__.py
+++ b/tools/sentry/__init__.py
@@ -1,0 +1,1 @@
+"""MaaFramework Sentry 遥测数据分析工具包。"""

--- a/tools/sentry/cli.py
+++ b/tools/sentry/cli.py
@@ -1,0 +1,68 @@
+"""统一运行 MaaFramework 应用 Sentry 分析报告。"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable, Sequence
+
+from . import task_failure_report, task_trend_report
+
+ReportMain = Callable[[Sequence[str] | None, str | None], int]
+
+
+REPORTS: dict[str, tuple[str, ReportMain]] = {
+    "task-failure": (
+        "生成单版本任务失败率深度分析报告",
+        task_failure_report.main,
+    ),
+    "task-trend": (
+        "生成任务跨版本表现与趋势对比报告",
+        task_trend_report.main,
+    ),
+    "task-compare": (
+        "生成任务跨版本表现与趋势对比报告(task-trend 别名)",
+        task_trend_report.main,
+    ),
+}
+
+
+def create_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog or "python -m tools.sentry.cli",
+        description="生成 MaaFramework 应用 Sentry 分析报告。",
+    )
+    subparsers = parser.add_subparsers(dest="report", metavar="REPORT")
+    for name, (description, _main) in REPORTS.items():
+        subparsers.add_parser(name, help=description, description=description)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    parser = create_argument_parser()
+    if not arguments or arguments[0] in {"-h", "--help"}:
+        parser.print_help()
+        return 0
+
+    report = REPORTS.get(arguments[0])
+    if report is None:
+        parser.error(f"未知报告类型:{arguments[0]}")
+
+    _description, report_main = report
+    try:
+        return report_main(
+            arguments[1:],
+            f"{parser.prog} {arguments[0]}",
+        )
+    except (FileNotFoundError, RuntimeError, ValueError) as error:
+        print(f"错误:{error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sentry/config.json
+++ b/tools/sentry/config.json
@@ -1,0 +1,15 @@
+{
+    "target": "m9a/gui",
+    "project_prefix": "m9a",
+    "release_pattern": null,
+    "task_run_spans": [
+        "mfa.task_run",
+        "mxu.task_run"
+    ],
+    "ignored_prefixes": [
+        "__MXU"
+    ],
+    "ignored_suffixes": [
+        ".task_run"
+    ]
+}

--- a/tools/sentry/config.py
+++ b/tools/sentry/config.py
@@ -1,0 +1,59 @@
+"""MaaFW Sentry 报告项目配置。
+
+统一从同级目录下的 config.json 读取；未配置或缺失必填项时直接抛出异常。
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ProjectConfig:
+    # Sentry 目标仓库 (<org>/<project>)
+    target: str
+    # 项目 Release 标识前缀 (例如 "m9a"、"MaaEnd"、"MAA")
+    project_prefix: str
+    # 可选: 自定义 Release 正则表达式 (未指定时根据 project_prefix 自动构造)
+    release_pattern: str | None = None
+    # 各渠道上报运行总量的 umbrella span 名称
+    task_run_spans: tuple[str, ...] = ()
+    # 任务列表中忽略的私有 span 前缀
+    ignored_prefixes: tuple[str, ...] = ()
+    # 任务列表中忽略的私有 span 后缀
+    ignored_suffixes: tuple[str, ...] = ()
+
+
+def load_config(config_path: Path | str | None = None) -> ProjectConfig:
+    """加载配置：从 config.json 读取；不存在或缺少必填字段时直接抛出异常。"""
+    config_file = Path(config_path) if config_path else Path(__file__).parent / "config.json"
+    if not config_file.is_file():
+        raise FileNotFoundError(f"未找到 Sentry 配置文件: {config_file}。请在 tools/sentry/ 目录下提供 config.json。")
+
+    with open(config_file, encoding="utf-8") as f:
+        data = json.load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"配置文件 {config_file} 内容格式错误，必须为 JSON 对象。")
+
+    target = data.get("target")
+    if not isinstance(target, str) or not target.strip():
+        raise ValueError(f"配置文件 {config_file} 缺少必填字段 'target' (例如 <org>/<project>)。")
+
+    project_prefix = data.get("project_prefix")
+    if not isinstance(project_prefix, str) or not project_prefix.strip():
+        raise ValueError(f"配置文件 {config_file} 缺少必填字段 'project_prefix'。")
+
+    return ProjectConfig(
+        target=target.strip(),
+        project_prefix=project_prefix.strip(),
+        release_pattern=data.get("release_pattern"),
+        task_run_spans=tuple(data.get("task_run_spans", ())),
+        ignored_prefixes=tuple(data.get("ignored_prefixes", ())),
+        ignored_suffixes=tuple(data.get("ignored_suffixes", ())),
+    )
+
+
+CONFIG = load_config()

--- a/tools/sentry/config.py
+++ b/tools/sentry/config.py
@@ -6,8 +6,10 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -24,6 +26,21 @@ class ProjectConfig:
     ignored_prefixes: tuple[str, ...] = ()
     # 任务列表中忽略的私有 span 后缀
     ignored_suffixes: tuple[str, ...] = ()
+
+
+def _parse_str_list(value: Any, field_name: str, config_file: Path) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(f"配置文件 {config_file} 中的 '{field_name}' 必须是字符串列表。")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(
+                f"配置文件 {config_file} 中的 '{field_name}' 列表项必须是字符串，发现: {type(item).__name__}"
+            )
+        result.append(item)
+    return tuple(result)
 
 
 def load_config(config_path: Path | str | None = None) -> ProjectConfig:
@@ -46,13 +63,27 @@ def load_config(config_path: Path | str | None = None) -> ProjectConfig:
     if not isinstance(project_prefix, str) or not project_prefix.strip():
         raise ValueError(f"配置文件 {config_file} 缺少必填字段 'project_prefix'。")
 
+    release_pattern = data.get("release_pattern")
+    if release_pattern is not None:
+        if not isinstance(release_pattern, str) or not release_pattern.strip():
+            raise ValueError(f"配置文件 {config_file} 中的 'release_pattern' 必须是非空字符串。")
+        try:
+            compiled = re.compile(release_pattern)
+            if compiled.groups != 5:
+                raise ValueError(
+                    f"配置文件 {config_file} 中的 'release_pattern' 必须包含恰好 5 个捕获组 "
+                    f"(major, minor, patch, prerelease, prerelease_number)，当前包含 {compiled.groups} 个。"
+                )
+        except re.error as err:
+            raise ValueError(f"配置文件 {config_file} 中的 'release_pattern' 正则表达式无效: {err}") from err
+
     return ProjectConfig(
         target=target.strip(),
         project_prefix=project_prefix.strip(),
-        release_pattern=data.get("release_pattern"),
-        task_run_spans=tuple(data.get("task_run_spans", ())),
-        ignored_prefixes=tuple(data.get("ignored_prefixes", ())),
-        ignored_suffixes=tuple(data.get("ignored_suffixes", ())),
+        release_pattern=release_pattern,
+        task_run_spans=_parse_str_list(data.get("task_run_spans"), "task_run_spans", config_file),
+        ignored_prefixes=_parse_str_list(data.get("ignored_prefixes"), "ignored_prefixes", config_file),
+        ignored_suffixes=_parse_str_list(data.get("ignored_suffixes"), "ignored_suffixes", config_file),
     )
 
 

--- a/tools/sentry/report_common.py
+++ b/tools/sentry/report_common.py
@@ -181,7 +181,7 @@ def release_version_key(release: str) -> tuple[int, int, int, int, int] | None:
         prerelease_rank = 2
         prerelease_number = "0"
     else:
-        prerelease_rank = {"beta": 0, "rc": 1}[prerelease.lower()]
+        prerelease_rank = {"beta": 0, "rc": 1}.get(prerelease.lower(), 0)
 
     return (
         int(major),

--- a/tools/sentry/report_common.py
+++ b/tools/sentry/report_common.py
@@ -170,18 +170,29 @@ def explore(
         cursor = next_cursor
 
 
+PRERELEASE_RANKS: dict[str, int] = {
+    "alpha": -1,
+    "beta": 0,
+    "rc": 1,
+}
+STABLE_RELEASE_RANK = 2
+
+
 def release_version_key(release: str) -> tuple[int, int, int, int, int] | None:
-    """解析 release 字符串内嵌的版本排序键,不匹配时返回 None。"""
+    """解析 release 字符串内嵌的版本排序键,不匹配或预发布类型未知时返回 None。"""
     match = RELEASE_PATTERN.search(release)
     if match is None:
         return None
 
     major, minor, patch, prerelease, prerelease_number = match.groups()
     if prerelease is None or prerelease_number is None:
-        prerelease_rank = 2
+        prerelease_rank = STABLE_RELEASE_RANK
         prerelease_number = "0"
     else:
-        prerelease_rank = {"beta": 0, "rc": 1}.get(prerelease.lower(), 0)
+        rank = PRERELEASE_RANKS.get(prerelease.lower())
+        if rank is None:
+            return None
+        prerelease_rank = rank
 
     return (
         int(major),

--- a/tools/sentry/report_common.py
+++ b/tools/sentry/report_common.py
@@ -1,0 +1,397 @@
+"""Sentry 报告脚本共用的查询和终端输出工具。
+
+提供 Sentry CLI 探测调用、Release 版本解析排序、游标分页拉取、
+以及宽字符对齐的控制台表格格式化。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import unicodedata
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any, TextIO
+from urllib.parse import quote
+
+try:
+    from .config import CONFIG
+except ImportError:
+    from config import CONFIG
+
+EXPLORE_LIMIT = 1_000
+DEFAULT_SENTRY_TIMEOUT_SECONDS = 120.0
+DEFAULT_RELEASE_DISCOVERY_PERIOD = "90d"
+MIN_RELEASE_UNIQUE_USERS = 10
+SENTRY_RELEASE_API_LIMIT = 100
+
+
+def get_release_pattern() -> re.Pattern[str]:
+    """获取项目 Release 匹配正则。"""
+    if CONFIG.release_pattern:
+        return re.compile(CONFIG.release_pattern)
+    prefix = CONFIG.project_prefix
+    return re.compile(
+        rf"(?:^|[+/]){re.escape(prefix)}@v?(\d+)\.(\d+)\.(\d+)(?:-(beta|rc)\.(\d+))?$",
+        re.IGNORECASE,
+    )
+
+
+RELEASE_PATTERN = get_release_pattern()
+M9A_RELEASE_PATTERN = RELEASE_PATTERN
+
+
+def resolve_sentry_command() -> str:
+    """查找当前系统中可执行的 sentry 命令。"""
+    candidates = ("sentry.cmd", "sentry.exe", "sentry") if os.name == "nt" else ("sentry",)
+    for candidate in candidates:
+        command = shutil.which(candidate)
+        if command:
+            return command
+    raise RuntimeError("未找到 sentry 命令。请先安装 Sentry CLI,并确认 sentry --version 可运行。")
+
+
+def run_sentry_json_value(
+    sentry_command: str,
+    arguments: Sequence[str],
+    *,
+    verbose: bool = False,
+    timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
+) -> Any:
+    """执行 Sentry CLI 并解析其 JSON 输出。"""
+    if verbose:
+        print(f"+ sentry {' '.join(arguments)}", file=sys.stderr)
+
+    try:
+        process = subprocess.run(
+            [sentry_command, *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(
+            f"sentry {' '.join(arguments)} 执行超过 {timeout_seconds:g} 秒,请检查网络、认证状态或缩短查询范围。"
+        ) from error
+    if process.returncode != 0:
+        diagnostic = process.stderr.strip() or process.stdout.strip()
+        raise RuntimeError(f"sentry {' '.join(arguments)} 执行失败(退出码 {process.returncode}):\n{diagnostic}")
+
+    try:
+        result = json.loads(process.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            f"sentry CLI 未返回有效 JSON:\nstdout:\n{process.stdout}\nstderr:\n{process.stderr}"
+        ) from error
+    return result
+
+
+def run_sentry_json(
+    sentry_command: str,
+    arguments: Sequence[str],
+    *,
+    verbose: bool = False,
+    timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """执行 Sentry CLI,并要求其返回 JSON 对象。"""
+    result = run_sentry_json_value(
+        sentry_command,
+        arguments,
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+    if not isinstance(result, dict):
+        raise RuntimeError("sentry CLI 返回了非对象 JSON。")
+    return result
+
+
+def explore(
+    sentry_command: str,
+    *,
+    target: str,
+    period: str,
+    fields: Sequence[str],
+    query: str,
+    sort: str | None = None,
+    verbose: bool = False,
+    timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    """查询 Sentry spans,并跟随游标返回全部分页结果。"""
+    base_arguments = ["explore", target, "--dataset", "spans"]
+    for field in fields:
+        base_arguments.extend(("--field", field))
+    base_arguments.extend(("--query", query))
+    if sort:
+        base_arguments.extend(("--sort", sort))
+    base_arguments.extend(
+        (
+            "--period",
+            period,
+            "--limit",
+            str(EXPLORE_LIMIT),
+            "--fresh",
+            "--json",
+        )
+    )
+
+    rows: list[dict[str, Any]] = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    while True:
+        arguments = [*base_arguments]
+        if cursor:
+            arguments.extend(("--cursor", cursor))
+        result = run_sentry_json(
+            sentry_command,
+            arguments,
+            verbose=verbose,
+            timeout_seconds=timeout_seconds,
+        )
+        data = result.get("data", [])
+        if not isinstance(data, list):
+            raise RuntimeError("sentry explore 返回的 data 不是数组。")
+        rows.extend(data)
+        if not result.get("hasMore"):
+            return rows
+
+        next_cursor = result.get("nextCursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            raise RuntimeError("sentry explore 声明存在下一页,但未返回有效游标。")
+        if next_cursor in seen_cursors:
+            raise RuntimeError(f"sentry explore 返回了重复分页游标:{next_cursor}")
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+
+def release_version_key(release: str) -> tuple[int, int, int, int, int] | None:
+    """解析 release 字符串内嵌的版本排序键,不匹配时返回 None。"""
+    match = RELEASE_PATTERN.search(release)
+    if match is None:
+        return None
+
+    major, minor, patch, prerelease, prerelease_number = match.groups()
+    if prerelease is None or prerelease_number is None:
+        prerelease_rank = 2
+        prerelease_number = "0"
+    else:
+        prerelease_rank = {"beta": 0, "rc": 1}[prerelease.lower()]
+
+    return (
+        int(major),
+        int(minor),
+        int(patch),
+        prerelease_rank,
+        int(prerelease_number),
+    )
+
+
+def version_label(release: str) -> str | None:
+    """从 release 字符串中提取内嵌的版本标签,例如 "v4.7.1"。"""
+    match = RELEASE_PATTERN.search(release)
+    if match is None:
+        return None
+    major, minor, patch, prerelease, prerelease_number = match.groups()
+    label = f"v{major}.{minor}.{patch}"
+    if prerelease is not None and prerelease_number is not None:
+        label += f"-{prerelease.lower()}.{prerelease_number}"
+    return label
+
+
+m9a_release_version_key = release_version_key
+m9a_version_label = version_label
+
+
+def select_latest_reported_release(
+    rows: Sequence[dict[str, Any]],
+) -> str | None:
+    """选择发布流程已 finalize 并记录 deploy 的最新 release。"""
+    candidates: list[tuple[datetime, tuple[int, int, int, int, int], str]] = []
+    for row in rows:
+        release = row.get("version")
+        released_at = row.get("dateReleased")
+        deploy_count = row.get("deployCount")
+        if (
+            not isinstance(release, str)
+            or not isinstance(released_at, str)
+            or not isinstance(deploy_count, int)
+            or deploy_count < 1
+        ):
+            continue
+
+        version = release_version_key(release)
+        if version is None:
+            continue
+        try:
+            release_time = datetime.fromisoformat(released_at.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        candidates.append((release_time, version, release))
+
+    return max(candidates)[2] if candidates else None
+
+
+select_latest_reported_m9a_release = select_latest_reported_release
+
+
+def select_latest_release(rows: Sequence[dict[str, Any]]) -> str:
+    """从 spans 中选择用户数达标的最新 release。"""
+    candidates: list[tuple[tuple[int, int, int, int, int], int, int, str]] = []
+    for row in rows:
+        release = row.get("release")
+        user_count = row.get("count_unique(user)")
+        trace_count = row.get("count_unique(trace)")
+        if (
+            not isinstance(release, str)
+            or not isinstance(user_count, int)
+            or not isinstance(trace_count, int)
+            or user_count < MIN_RELEASE_UNIQUE_USERS
+        ):
+            continue
+
+        version = release_version_key(release)
+        if version is None:
+            continue
+        candidates.append((version, user_count, trace_count, release))
+
+    if not candidates:
+        prefix_desc = f"{CONFIG.project_prefix}@" if CONFIG.project_prefix else ""
+        raise RuntimeError(
+            f"Sentry 中找不到格式为 {prefix_desc}vX.Y.Z 或 {prefix_desc}vX.Y.Z-beta.N、"
+            f"且至少有 {MIN_RELEASE_UNIQUE_USERS} 位独立用户的 release,"
+            "请通过 --release 显式指定。"
+        )
+    return max(candidates)[3]
+
+
+select_latest_m9a_release = select_latest_release
+
+
+def query_sentry_releases(
+    sentry_command: str,
+    *,
+    target: str,
+    verbose: bool = False,
+    timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    """查询项目最新一页的 Sentry release 元数据。"""
+    organization, separator, project = target.partition("/")
+    if not separator or not organization or not project or "/" in project:
+        raise ValueError(f"无效的 Sentry target:{target!r},应为 <org>/<project>。")
+
+    endpoint = (
+        f"projects/{quote(organization, safe='')}/{quote(project, safe='')}/"
+        f"releases/?per_page={SENTRY_RELEASE_API_LIMIT}"
+    )
+    result = run_sentry_json_value(
+        sentry_command,
+        ("api", endpoint, "--json"),
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+    if not isinstance(result, list) or not all(isinstance(row, dict) for row in result):
+        raise RuntimeError("Sentry release API 返回的 JSON 不是对象数组。")
+    return result
+
+
+def resolve_latest_release(
+    sentry_command: str,
+    *,
+    target: str,
+    verbose: bool = False,
+    timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
+) -> str:
+    """优先使用发布流程上报的 release,旧版本回退到 spans 样本。"""
+    release_rows = query_sentry_releases(
+        sentry_command,
+        target=target,
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+    reported_release = select_latest_reported_release(release_rows)
+    if reported_release is not None:
+        return reported_release
+
+    rows = explore(
+        sentry_command,
+        target=target,
+        period=DEFAULT_RELEASE_DISCOVERY_PERIOD,
+        fields=("release", "count_unique(user)", "count_unique(trace)"),
+        query="",
+        sort="-count_unique(user)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+    return select_latest_release(rows)
+
+
+resolve_latest_m9a_release = resolve_latest_release
+
+
+def format_rate(rate: float | None) -> str:
+    """把小数失败率格式化为百分比。"""
+    return "暂无样本" if rate is None else f"{rate:.1%}"
+
+
+def show_progress(message: str, *, quiet: bool) -> None:
+    """向标准错误输出阶段进度,不污染报告正文。"""
+    if not quiet:
+        print(message, file=sys.stderr, flush=True)
+
+
+def display_width(value: str) -> int:
+    """计算终端中的 Unicode 显示宽度,中文等宽字符按两列计算。"""
+    width = 0
+    for character in value:
+        if unicodedata.combining(character):
+            continue
+        width += 2 if unicodedata.east_asian_width(character) in {"F", "W"} else 1
+    return width
+
+
+def pad_display(value: str, width: int, *, align_right: bool = False) -> str:
+    """按照终端显示宽度填充文本。"""
+    padding = " " * (width - display_width(value))
+    return f"{padding}{value}" if align_right else f"{value}{padding}"
+
+
+def write_console_table(
+    headers: Sequence[str],
+    values: Sequence[Sequence[str]],
+    output: TextIO,
+    *,
+    right_aligned: set[int] | None = None,
+) -> None:
+    """输出处理中日韩宽字符的 Unicode 框线表格。"""
+    alignments = right_aligned or set()
+    widths = [
+        max(display_width(value) for value in (header, *(row[index] for row in values)))
+        for index, header in enumerate(headers)
+    ]
+
+    def border(left: str, middle: str, right: str) -> str:
+        return left + middle.join("─" * (width + 2) for width in widths) + right
+
+    def table_row(row: Sequence[str], *, header: bool = False) -> str:
+        cells = [
+            pad_display(
+                value,
+                widths[index],
+                align_right=index in alignments and not header,
+            )
+            for index, value in enumerate(row)
+        ]
+        return "│ " + " │ ".join(cells) + " │"
+
+    print(border("┌", "┬", "┐"), file=output)
+    print(table_row(headers, header=True), file=output)
+    print(border("├", "┼", "┤"), file=output)
+    for row in values:
+        print(table_row(row), file=output)
+    print(border("└", "┴", "┘"), file=output)

--- a/tools/sentry/task_failure_report.py
+++ b/tools/sentry/task_failure_report.py
@@ -1,0 +1,504 @@
+"""根据 Sentry spans 生成任务失败率分析报告。
+
+默认分析 Sentry 上最新的应用版本最近 7 天的任务运行数据。
+任务级分析按版本聚合：同一版本由多个渠道 release 内嵌，
+查询覆盖内嵌该版本的全部渠道。trace 归属唯一 release，跨渠道求和不产生重复计数。
+
+报告区分三种口径，均按唯一 trace 去重：
+
+- **任务结果**：任务级 span 按 ok / internal_error / cancelled 分列，
+  失败率 = 失败 trace 数 / 总 trace 数，是最接近“这个任务失败概率”的口径；
+- **失败节点标记**：仅在节点失败时才上报的 span 和系统级失败（控制器初始化失败等），
+  没有成功样本，“触发次数”即触发该失败的运行数，不参与失败率计算；
+- **运行失败率**：各渠道 umbrella span 的 internal_error 占比，即“一次完整运行失败的概率”，
+  用于跨渠道对比。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any, TextIO
+
+try:
+    from .report_common import (
+        DEFAULT_SENTRY_TIMEOUT_SECONDS,
+        explore,
+        format_rate,
+        release_version_key,
+        resolve_latest_release,
+        resolve_sentry_command,
+        show_progress,
+        version_label,
+        write_console_table,
+    )
+except ImportError:
+    from report_common import (
+        DEFAULT_SENTRY_TIMEOUT_SECONDS,
+        explore,
+        format_rate,
+        release_version_key,
+        resolve_latest_release,
+        resolve_sentry_command,
+        show_progress,
+        version_label,
+        write_console_table,
+    )
+
+try:
+    from .config import CONFIG
+except ImportError:
+    from config import CONFIG
+
+
+DEFAULT_TARGET = CONFIG.target
+DEFAULT_PERIOD = "7d"
+INTERNAL_ERROR = "internal_error"
+CANCELLED = "cancelled"
+OK = "ok"
+# 各渠道上报"整次运行"的 umbrella span 名称。
+TASK_RUN_SPANS = CONFIG.task_run_spans
+UMBRELLA_FILTER = f"span.description:[{','.join(TASK_RUN_SPANS)}]"
+SYSTEM_LABELS = {
+    "controller_initialization_failed": "控制器初始化失败",
+    "connection_failed": "连接失败",
+    "agent_start_failed": "Agent 启动失败",
+    "resource_initialization_failed": "资源初始化失败",
+    "controller_link_start_failed": "控制器连接失败",
+}
+
+
+@dataclass(frozen=True)
+class TaskRow:
+    task: str
+    total: int
+    failed: int
+    cancelled: int
+    failure_rate: float | None
+
+
+@dataclass(frozen=True)
+class ReleaseRow:
+    release: str
+    total: int
+    failed: int
+    failure_rate: float
+
+
+@dataclass(frozen=True)
+class Report:
+    release: str
+    version: str | None
+    tasks: list[TaskRow]
+    markers: list[TaskRow]
+    runs: list[ReleaseRow]
+
+
+def describe(description: str) -> str:
+    """把系统级 span 描述翻译为可读标签,任务名保持原样。"""
+    return SYSTEM_LABELS.get(description, description)
+
+
+def _unique_trace_count(row: dict[str, Any], key: str) -> int | None:
+    value = row.get(key)
+    return value if isinstance(value, int) else None
+
+
+def _in_version(row: dict[str, Any], version_key: tuple[int, int, int, int, int] | None) -> bool:
+    """判断行是否属于目标版本;无法判定(行缺少 release)时视为属于。"""
+    if version_key is None:
+        return True
+    release = row.get("release")
+    if not isinstance(release, str):
+        return True
+    return release_version_key(release) == version_key
+
+
+def build_task_rows(
+    totals: Iterable[dict[str, Any]],
+    statuses: Iterable[dict[str, Any]],
+    version_key: tuple[int, int, int, int, int] | None,
+    *,
+    sort: str = "failures",
+    reverse: bool = False,
+    limit: int | None = None,
+) -> tuple[list[TaskRow], list[TaskRow]]:
+    """根据任务执行总量与各状态 trace 行聚合各任务的成功率与失败率。"""
+    total_by_task: dict[str, int] = defaultdict(int)
+    status_by_task: dict[str, dict[str, int]] = defaultdict(dict)
+    for row in totals:
+        if not _in_version(row, version_key):
+            continue
+        description = row.get("span.description")
+        if not isinstance(description, str):
+            continue
+        count = _unique_trace_count(row, "count_unique(trace)")
+        if count is not None:
+            total_by_task[description] += count
+
+    for row in statuses:
+        if not _in_version(row, version_key):
+            continue
+        description = row.get("span.description")
+        if not isinstance(description, str):
+            continue
+        count = _unique_trace_count(row, "count_unique(trace)")
+        if count is None:
+            continue
+        status = str(row["span.status"])
+        status_by_task[description][status] = status_by_task[description].get(status, 0) + count
+
+    tasks: list[TaskRow] = []
+    markers: list[TaskRow] = []
+    for description in total_by_task.keys() | status_by_task.keys():
+        status_counts = status_by_task.get(description, {})
+        failed = status_counts.get(INTERNAL_ERROR, 0)
+        cancelled = status_counts.get(CANCELLED, 0)
+        ok = status_counts.get(OK, 0)
+        if ok == 0 and cancelled == 0 and failed > 0:
+            markers.append(TaskRow(task=description, total=failed, failed=failed, cancelled=0, failure_rate=None))
+            continue
+        total = total_by_task.get(description) or (ok + failed + cancelled)
+        failed = min(failed, total)
+        cancelled = min(cancelled, total - failed)
+        tasks.append(
+            TaskRow(
+                task=description,
+                total=total,
+                failed=failed,
+                cancelled=cancelled,
+                failure_rate=failed / total if total else None,
+            )
+        )
+
+    if sort == "rate":
+        tasks.sort(
+            key=lambda row: (row.failure_rate is not None, row.failure_rate or 0.0, row.total),
+            reverse=not reverse,
+        )
+    elif sort == "total":
+        tasks.sort(key=lambda row: (row.total, row.task), reverse=not reverse)
+    elif sort == "name":
+        tasks.sort(key=lambda row: row.task, reverse=reverse)
+    else:  # "failures" (默认)
+        tasks.sort(key=lambda row: (row.failed, row.total, row.task), reverse=not reverse)
+
+    markers.sort(key=lambda row: (-row.total, row.task))
+    if limit is not None and limit > 0:
+        tasks = tasks[:limit]
+        markers = markers[:limit]
+
+    return tasks, markers
+
+
+def build_release_rows(
+    totals: Iterable[dict[str, Any]],
+    failures: Iterable[dict[str, Any]],
+    version_key: tuple[int, int, int, int, int] | None,
+) -> list[ReleaseRow]:
+    """按 release 字符串聚合运行失败率;version_key 非空时仅保留内嵌同版本号的渠道。"""
+    total_by_release: dict[str, int] = {}
+    failed_by_release: dict[str, int] = defaultdict(int)
+    for row in totals:
+        release = str(row["release"])
+        count = _unique_trace_count(row, "count_unique(trace)")
+        if count is not None:
+            total_by_release[release] = count
+    for row in failures:
+        release = str(row["release"])
+        count = _unique_trace_count(row, "count_unique(trace)")
+        if count is not None:
+            failed_by_release[release] = count
+
+    report = []
+    for release, total in total_by_release.items():
+        if version_key is not None and release_version_key(release) != version_key:
+            continue
+        failed = failed_by_release.get(release, 0)
+        report.append(
+            ReleaseRow(
+                release=release,
+                total=total,
+                failed=failed,
+                failure_rate=failed / total if total else 0.0,
+            )
+        )
+    return sorted(report, key=lambda row: (-row.total, row.release))
+
+
+def collect_report(
+    *,
+    sentry_command: str,
+    release: str | None,
+    target: str,
+    period: str,
+    sort: str = "failures",
+    reverse: bool = False,
+    limit: int | None = None,
+    timeout_seconds: float,
+    verbose: bool,
+    quiet: bool,
+) -> Report:
+    if release is None:
+        show_progress("[0/4] 自动选择最新版本", quiet=quiet)
+        release = resolve_latest_release(
+            sentry_command,
+            target=target,
+            verbose=verbose,
+            timeout_seconds=timeout_seconds,
+        )
+    version_key = release_version_key(release)
+    version = version_label(release)
+    if version is not None:
+        show_progress(
+            f"分析版本 {version}(版本确定自 release:{release},任务数据聚合覆盖所有内嵌该版本的渠道)",
+            quiet=quiet,
+        )
+    else:
+        show_progress(f"分析单个 Sentry release:{release}", quiet=quiet)
+    escaped_release = release.replace('"', '\\"')
+    scope_filter = f'release:"{escaped_release}"'
+    # 任务级分析按版本聚合:同一版本内嵌于多个渠道 release,
+    # 查询不带 release 过滤,取回后按版本键本地过滤。
+    # release 无法解析出版本时(--release 传入了非标准字符串),
+    # 回退为按该 release 精确过滤。
+    task_query = "" if version_key is not None else scope_filter
+
+    show_progress("[1/4] 查询任务执行总量", quiet=quiet)
+    task_total_rows = explore(
+        sentry_command,
+        target=target,
+        period=period,
+        fields=("span.description", "release", "count_unique(trace)"),
+        query=task_query,
+        sort="-count_unique(trace)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+
+    show_progress("[2/4] 查询任务结果分布", quiet=quiet)
+    task_status_rows = explore(
+        sentry_command,
+        target=target,
+        period=period,
+        fields=("span.description", "span.status", "release", "count_unique(trace)"),
+        query=task_query,
+        sort="-count_unique(trace)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+
+    show_progress("[3/4] 查询各渠道运行总量", quiet=quiet)
+    run_total_rows = explore(
+        sentry_command,
+        target=target,
+        period=period,
+        fields=("release", "count_unique(trace)"),
+        query=UMBRELLA_FILTER,
+        sort="-count_unique(trace)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+
+    show_progress("[4/4] 查询各渠道运行失败分布", quiet=quiet)
+    run_failure_rows = explore(
+        sentry_command,
+        target=target,
+        period=period,
+        fields=("release", "count_unique(trace)"),
+        query=f"{UMBRELLA_FILTER} span.status:{INTERNAL_ERROR}",
+        sort="-count_unique(trace)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+
+    runs = build_release_rows(run_total_rows, run_failure_rows, version_key)
+
+    tasks, markers = build_task_rows(
+        task_total_rows,
+        task_status_rows,
+        version_key,
+        sort=sort,
+        reverse=reverse,
+        limit=limit,
+    )
+    return Report(
+        release=release,
+        version=version,
+        tasks=tasks,
+        markers=markers,
+        runs=runs,
+    )
+
+
+def write_console(report: Report, output: TextIO) -> None:
+    if report.version:
+        print(f"版本: {report.version}", file=output)
+    else:
+        print(f"Sentry release: {report.release}", file=output)
+    print("报告内所有次数均按唯一 trace 去重。\n", file=output)
+    write_console_table(
+        ("任务", "总次数", "失败", "取消", "失败率"),
+        [
+            (row.task, str(row.total), str(row.failed), str(row.cancelled), format_rate(row.failure_rate))
+            for row in report.tasks
+        ],
+        output,
+        right_aligned={1, 2, 3, 4},
+    )
+
+    print("\n失败节点标记", file=output)
+    print("以下 span 仅在失败时上报;触发次数即触发该失败的任务运行数,不参与失败率计算。\n", file=output)
+    write_console_table(
+        ("节点/系统", "触发次数"),
+        [(describe(row.task), str(row.total)) for row in report.markers],
+        output,
+        right_aligned={1},
+    )
+
+    spans_desc = " / ".join(TASK_RUN_SPANS)
+    print("\n运行失败率(跨渠道对比)", file=output)
+    print(
+        f"口径:各渠道 umbrella span({spans_desc})的失败率,"
+        "即一次完整运行失败的占比。release 字符串由渠道注册,内嵌相同的版本号。\n",
+        file=output,
+    )
+    write_console_table(
+        ("release", "运行数", "失败", "失败率"),
+        [(row.release, str(row.total), str(row.failed), format_rate(row.failure_rate)) for row in report.runs],
+        output,
+        right_aligned={1, 2, 3},
+    )
+
+
+def write_markdown(report: Report, output: TextIO) -> None:
+    if report.version:
+        print(f"> 版本: {report.version}\n", file=output)
+    else:
+        print(f"> Sentry release: `{report.release}`\n", file=output)
+    print("> 报告内所有次数均按唯一 trace 去重。\n", file=output)
+    print("## 任务失败率\n", file=output)
+    print("| 任务 | 总次数 | 失败 | 取消 | 失败率 |", file=output)
+    print("|---|---:|---:|---:|---:|", file=output)
+    for row in report.tasks:
+        print(
+            f"| {row.task} | {row.total} | {row.failed} | {row.cancelled} | {format_rate(row.failure_rate)} |",
+            file=output,
+        )
+
+    print("\n## 失败节点标记\n", file=output)
+    print("> 以下 span 仅在失败时上报;触发次数即触发该失败的任务运行数,不参与失败率计算。\n", file=output)
+    print("| 节点/系统 | 触发次数 |", file=output)
+    print("|---|---:|", file=output)
+    for row in report.markers:
+        print(f"| {describe(row.task)} | {row.total} |", file=output)
+
+    spans_desc = " / ".join(TASK_RUN_SPANS)
+    print("\n## 运行失败率(跨渠道对比)\n", file=output)
+    print(
+        f"> 口径:各渠道 umbrella span({spans_desc})的失败率,即一次完整运行失败的占比。\n",
+        file=output,
+    )
+    print("| release | 运行数 | 失败 | 失败率 |", file=output)
+    print("|---|---:|---:|---:|", file=output)
+    for row in report.runs:
+        print(
+            f"| `{row.release}` | {row.total} | {row.failed} | {format_rate(row.failure_rate)} |",
+            file=output,
+        )
+
+
+def write_json(report: Report, output: TextIO) -> None:
+    json.dump(asdict(report), output, ensure_ascii=False, indent=2)
+    output.write("\n")
+
+
+def create_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description=__doc__)
+    parser.add_argument(
+        "--release",
+        help=("指定 Sentry release(取其内嵌的项目版本);未指定时自动选择最新版本"),
+    )
+    parser.add_argument("--target", default=DEFAULT_TARGET, help="<org>/<project>")
+    parser.add_argument(
+        "--period",
+        default=DEFAULT_PERIOD,
+        help='查询范围,例如 "24h"、"7d" 或 "2026-08-23..2026-08-24"',
+    )
+    parser.add_argument(
+        "--sort",
+        choices=("failures", "rate", "total", "name"),
+        default="failures",
+        help="任务排序规则: failures(失败次数从多到少,默认), rate(失败率从高到低), total(总次数从多到少), name(任务名)",
+    )
+    parser.add_argument(
+        "--reverse",
+        action="store_true",
+        help="反转排序顺序",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="限制展示的任务数量(如 --limit 10 仅展示前 10 个任务)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("console", "markdown", "json"),
+        default="console",
+        help="输出格式",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_SENTRY_TIMEOUT_SECONDS,
+        help="单次 Sentry 查询超时秒数(默认:120)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="输出 sentry 查询命令")
+    parser.add_argument("--quiet", action="store_true", help="不输出查询进度")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+
+    arguments = create_argument_parser(prog).parse_args(argv)
+    if not math.isfinite(arguments.timeout) or arguments.timeout <= 0:
+        raise ValueError("--timeout 必须是大于 0 的有限数值。")
+    if arguments.limit is not None and arguments.limit <= 0:
+        raise ValueError("--limit 必须是大于 0 的整数。")
+
+    report = collect_report(
+        sentry_command=resolve_sentry_command(),
+        release=arguments.release,
+        target=arguments.target,
+        period=arguments.period,
+        sort=arguments.sort,
+        reverse=arguments.reverse,
+        limit=arguments.limit,
+        timeout_seconds=arguments.timeout,
+        verbose=arguments.verbose,
+        quiet=arguments.quiet,
+    )
+    writers = {
+        "console": write_console,
+        "markdown": write_markdown,
+        "json": write_json,
+    }
+    writers[arguments.format](report, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (FileNotFoundError, RuntimeError, ValueError) as error:
+        print(f"错误:{error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/tools/sentry/task_failure_report.py
+++ b/tools/sentry/task_failure_report.py
@@ -61,9 +61,8 @@ DEFAULT_PERIOD = "7d"
 INTERNAL_ERROR = "internal_error"
 CANCELLED = "cancelled"
 OK = "ok"
-# 各渠道上报"整次运行"的 umbrella span 名称。
 TASK_RUN_SPANS = CONFIG.task_run_spans
-UMBRELLA_FILTER = f"span.description:[{','.join(TASK_RUN_SPANS)}]"
+UMBRELLA_FILTER = f"span.description:[{','.join(TASK_RUN_SPANS)}]" if TASK_RUN_SPANS else ""
 SYSTEM_LABELS = {
     "controller_initialization_failed": "控制器初始化失败",
     "connection_failed": "连接失败",
@@ -110,12 +109,12 @@ def _unique_trace_count(row: dict[str, Any], key: str) -> int | None:
 
 
 def _in_version(row: dict[str, Any], version_key: tuple[int, int, int, int, int] | None) -> bool:
-    """判断行是否属于目标版本;无法判定(行缺少 release)时视为属于。"""
+    """判断行是否属于目标版本；当指定了目标版本时，缺少或无效 release 的行不属于该版本。"""
     if version_key is None:
         return True
     release = row.get("release")
     if not isinstance(release, str):
-        return True
+        return False
     return release_version_key(release) == version_key
 
 
@@ -188,7 +187,7 @@ def build_task_rows(
     else:  # "failures" (默认)
         tasks.sort(key=lambda row: (row.failed, row.total, row.task), reverse=not reverse)
 
-    markers.sort(key=lambda row: (-row.total, row.task))
+    markers.sort(key=lambda row: (row.total, row.task), reverse=not reverse)
     if limit is not None and limit > 0:
         tasks = tasks[:limit]
         markers = markers[:limit]
@@ -200,8 +199,13 @@ def build_release_rows(
     totals: Iterable[dict[str, Any]],
     failures: Iterable[dict[str, Any]],
     version_key: tuple[int, int, int, int, int] | None,
+    *,
+    target_release: str | None = None,
 ) -> list[ReleaseRow]:
-    """按 release 字符串聚合运行失败率;version_key 非空时仅保留内嵌同版本号的渠道。"""
+    """按 release 字符串聚合运行失败率。
+
+    version_key 非空时仅保留内嵌同版本号的渠道；否则若指定 target_release 则仅保留该 release。
+    """
     total_by_release: dict[str, int] = {}
     failed_by_release: dict[str, int] = defaultdict(int)
     for row in totals:
@@ -217,8 +221,12 @@ def build_release_rows(
 
     report = []
     for release, total in total_by_release.items():
-        if version_key is not None and release_version_key(release) != version_key:
-            continue
+        if version_key is not None:
+            if release_version_key(release) != version_key:
+                continue
+        elif target_release is not None:
+            if release != target_release:
+                continue
         failed = failed_by_release.get(release, 0)
         report.append(
             ReleaseRow(
@@ -293,31 +301,37 @@ def collect_report(
         timeout_seconds=timeout_seconds,
     )
 
-    show_progress("[3/4] 查询各渠道运行总量", quiet=quiet)
-    run_total_rows = explore(
-        sentry_command,
-        target=target,
-        period=period,
-        fields=("release", "count_unique(trace)"),
-        query=UMBRELLA_FILTER,
-        sort="-count_unique(trace)",
-        verbose=verbose,
-        timeout_seconds=timeout_seconds,
-    )
+    runs: list[ReleaseRow] = []
+    if TASK_RUN_SPANS:
+        umbrella_query = f"{scope_filter} {UMBRELLA_FILTER}".strip()
+        show_progress("[3/4] 查询各渠道运行总量", quiet=quiet)
+        run_total_rows = explore(
+            sentry_command,
+            target=target,
+            period=period,
+            fields=("release", "count_unique(trace)"),
+            query=umbrella_query,
+            sort="-count_unique(trace)",
+            verbose=verbose,
+            timeout_seconds=timeout_seconds,
+        )
 
-    show_progress("[4/4] 查询各渠道运行失败分布", quiet=quiet)
-    run_failure_rows = explore(
-        sentry_command,
-        target=target,
-        period=period,
-        fields=("release", "count_unique(trace)"),
-        query=f"{UMBRELLA_FILTER} span.status:{INTERNAL_ERROR}",
-        sort="-count_unique(trace)",
-        verbose=verbose,
-        timeout_seconds=timeout_seconds,
-    )
+        show_progress("[4/4] 查询各渠道运行失败分布", quiet=quiet)
+        run_failure_rows = explore(
+            sentry_command,
+            target=target,
+            period=period,
+            fields=("release", "count_unique(trace)"),
+            query=f"{umbrella_query} span.status:{INTERNAL_ERROR}".strip(),
+            sort="-count_unique(trace)",
+            verbose=verbose,
+            timeout_seconds=timeout_seconds,
+        )
 
-    runs = build_release_rows(run_total_rows, run_failure_rows, version_key)
+        runs = build_release_rows(run_total_rows, run_failure_rows, version_key, target_release=release)
+    else:
+        show_progress("[3/4] 未配置 umbrella span，跳过渠道运行查询", quiet=quiet)
+        show_progress("[4/4] 完成任务聚合", quiet=quiet)
 
     tasks, markers = build_task_rows(
         task_total_rows,
@@ -361,19 +375,20 @@ def write_console(report: Report, output: TextIO) -> None:
         right_aligned={1},
     )
 
-    spans_desc = " / ".join(TASK_RUN_SPANS)
-    print("\n运行失败率(跨渠道对比)", file=output)
-    print(
-        f"口径:各渠道 umbrella span({spans_desc})的失败率,"
-        "即一次完整运行失败的占比。release 字符串由渠道注册,内嵌相同的版本号。\n",
-        file=output,
-    )
-    write_console_table(
-        ("release", "运行数", "失败", "失败率"),
-        [(row.release, str(row.total), str(row.failed), format_rate(row.failure_rate)) for row in report.runs],
-        output,
-        right_aligned={1, 2, 3},
-    )
+    if report.runs:
+        spans_desc = " / ".join(TASK_RUN_SPANS)
+        print("\n运行失败率(跨渠道对比)", file=output)
+        print(
+            f"口径:各渠道 umbrella span({spans_desc})的失败率,"
+            "即一次完整运行失败的占比。release 字符串由渠道注册,内嵌相同的版本号。\n",
+            file=output,
+        )
+        write_console_table(
+            ("release", "运行数", "失败", "失败率"),
+            [(row.release, str(row.total), str(row.failed), format_rate(row.failure_rate)) for row in report.runs],
+            output,
+            right_aligned={1, 2, 3},
+        )
 
 
 def write_markdown(report: Report, output: TextIO) -> None:
@@ -398,19 +413,20 @@ def write_markdown(report: Report, output: TextIO) -> None:
     for row in report.markers:
         print(f"| {describe(row.task)} | {row.total} |", file=output)
 
-    spans_desc = " / ".join(TASK_RUN_SPANS)
-    print("\n## 运行失败率(跨渠道对比)\n", file=output)
-    print(
-        f"> 口径:各渠道 umbrella span({spans_desc})的失败率,即一次完整运行失败的占比。\n",
-        file=output,
-    )
-    print("| release | 运行数 | 失败 | 失败率 |", file=output)
-    print("|---|---:|---:|---:|", file=output)
-    for row in report.runs:
+    if report.runs:
+        spans_desc = " / ".join(TASK_RUN_SPANS)
+        print("\n## 运行失败率(跨渠道对比)\n", file=output)
         print(
-            f"| `{row.release}` | {row.total} | {row.failed} | {format_rate(row.failure_rate)} |",
+            f"> 口径:各渠道 umbrella span({spans_desc})的失败率,即一次完整运行失败的占比。\n",
             file=output,
         )
+        print("| release | 运行数 | 失败 | 失败率 |", file=output)
+        print("|---|---:|---:|---:|", file=output)
+        for row in report.runs:
+            print(
+                f"| `{row.release}` | {row.total} | {row.failed} | {format_rate(row.failure_rate)} |",
+                file=output,
+            )
 
 
 def write_json(report: Report, output: TextIO) -> None:

--- a/tools/sentry/task_failure_report.py
+++ b/tools/sentry/task_failure_report.py
@@ -303,7 +303,7 @@ def collect_report(
 
     runs: list[ReleaseRow] = []
     if TASK_RUN_SPANS:
-        umbrella_query = f"{scope_filter} {UMBRELLA_FILTER}".strip()
+        umbrella_query = UMBRELLA_FILTER if version_key is not None else f"{scope_filter} {UMBRELLA_FILTER}".strip()
         show_progress("[3/4] 查询各渠道运行总量", quiet=quiet)
         run_total_rows = explore(
             sentry_command,

--- a/tools/sentry/task_trend_report.py
+++ b/tools/sentry/task_trend_report.py
@@ -22,6 +22,7 @@ try:
         DEFAULT_RELEASE_DISCOVERY_PERIOD,
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         MIN_RELEASE_UNIQUE_USERS,
+        STABLE_RELEASE_RANK,
         explore,
         release_version_key,
         resolve_sentry_command,
@@ -34,6 +35,7 @@ except ImportError:
         DEFAULT_RELEASE_DISCOVERY_PERIOD,
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         MIN_RELEASE_UNIQUE_USERS,
+        STABLE_RELEASE_RANK,
         explore,
         release_version_key,
         resolve_sentry_command,
@@ -136,8 +138,8 @@ def discover_versions(
         label = version_label(release)
         if key is None or label is None:
             continue
-        # key[3] == 2 代表正式稳定版,0/1 分别为 beta/rc
-        if not include_prerelease and key[3] != 2:
+        # key[3] == STABLE_RELEASE_RANK 代表正式稳定版,其余为 alpha/beta/rc
+        if not include_prerelease and key[3] != STABLE_RELEASE_RANK:
             continue
         version_users[key] += user_count
         version_labels[key] = label

--- a/tools/sentry/task_trend_report.py
+++ b/tools/sentry/task_trend_report.py
@@ -153,6 +153,7 @@ def build_trend_report(
     statuses: Iterable[dict[str, Any]],
     versions: Sequence[str],
     *,
+    display_versions: Sequence[str] | None = None,
     task_filter: str | None = None,
     min_latest_runs: int = DEFAULT_MIN_LATEST_RUNS,
     sort: str = "runs",
@@ -185,17 +186,28 @@ def build_trend_report(
             elif status == "ok":
                 task_oks[description] += count
 
+    target_versions = set(display_versions) if display_versions else version_set
     all_tasks = set()
-    for v in version_set:
+    for v in target_versions:
         all_tasks.update(task_totals[v].keys())
 
     # 若指定了单任务筛选,提取单任务在各个版本下的详细统计
     detailed_stats: list[VersionTaskStat] | None = None
+    resolved_task_filter = task_filter
     if task_filter:
-        target_task = next(
-            (t for t in all_tasks if task_filter.lower() in t.lower()),
-            task_filter,
-        )
+        exact_match = next((t for t in sorted(all_tasks) if t.lower() == task_filter.lower()), None)
+        if exact_match is not None:
+            target_task = exact_match
+        else:
+            fuzzy_matches = [t for t in sorted(all_tasks) if task_filter.lower() in t.lower()]
+            if len(fuzzy_matches) == 1:
+                target_task = fuzzy_matches[0]
+            elif len(fuzzy_matches) > 1:
+                candidates = ", ".join(f"'{m}'" for m in fuzzy_matches)
+                raise ValueError(f"任务筛选 '{task_filter}' 匹配到多个候选任务: {candidates}。请指定更精确的任务名称。")
+            else:
+                target_task = task_filter
+        resolved_task_filter = target_task
         detailed_stats = []
         for i, version in enumerate(versions):
             tot = task_totals[version].get(target_task, 0)
@@ -298,7 +310,7 @@ def build_trend_report(
     return TrendReport(
         versions=list(versions),
         rows=rows,
-        task_filter=task_filter,
+        task_filter=resolved_task_filter,
         detailed_task_stats=detailed_stats,
     )
 
@@ -380,6 +392,7 @@ def collect_report(
         totals,
         statuses,
         query_versions,
+        display_versions=display_versions,
         task_filter=task_filter,
         min_latest_runs=min_latest_runs,
         sort=sort,
@@ -390,7 +403,7 @@ def collect_report(
     return TrendReport(
         versions=display_versions,
         rows=report.rows,
-        task_filter=task_filter,
+        task_filter=report.task_filter,
         detailed_task_stats=(
             [s for s in report.detailed_task_stats if s.version in display_versions]
             if report.detailed_task_stats

--- a/tools/sentry/task_trend_report.py
+++ b/tools/sentry/task_trend_report.py
@@ -1,0 +1,582 @@
+"""根据 Sentry spans 生成任务在多个版本间的表现与趋势对比报告。
+
+支持对比最近 N 个正式版本(或包含测试版)的任务失败率走势,在各版本后使用括号
+备注相对前一版本的百分点变化量(如 ``5.6% (-1.4pp)``)。
+
+任务级数据按版本聚合覆盖所有内嵌该版本的渠道,并按唯一 trace 去重计数。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any, TextIO
+
+try:
+    from .report_common import (
+        DEFAULT_RELEASE_DISCOVERY_PERIOD,
+        DEFAULT_SENTRY_TIMEOUT_SECONDS,
+        MIN_RELEASE_UNIQUE_USERS,
+        explore,
+        release_version_key,
+        resolve_sentry_command,
+        show_progress,
+        version_label,
+        write_console_table,
+    )
+except ImportError:
+    from report_common import (
+        DEFAULT_RELEASE_DISCOVERY_PERIOD,
+        DEFAULT_SENTRY_TIMEOUT_SECONDS,
+        MIN_RELEASE_UNIQUE_USERS,
+        explore,
+        release_version_key,
+        resolve_sentry_command,
+        show_progress,
+        version_label,
+        write_console_table,
+    )
+
+try:
+    from .config import CONFIG
+except ImportError:
+    from config import CONFIG
+
+DEFAULT_TARGET = CONFIG.target
+DEFAULT_VERSIONS_COUNT = 3
+DEFAULT_MIN_LATEST_RUNS = 10
+INTERNAL_ERROR = "internal_error"
+SYSTEM_LABELS = {
+    "controller_initialization_failed": "控制器初始化失败",
+    "connection_failed": "连接失败",
+    "agent_start_failed": "Agent 启动失败",
+    "resource_initialization_failed": "资源初始化失败",
+    "controller_link_start_failed": "控制器连接失败",
+}
+
+
+@dataclass(frozen=True)
+class VersionTaskStat:
+    """单个版本内某一任务的详细统计。"""
+
+    version: str
+    total: int
+    failed: int
+    failure_rate: float | None
+    delta_pp: float | None = None
+
+
+@dataclass(frozen=True)
+class TaskTrendRow:
+    """多版本对比表中某一任务的汇总行。"""
+
+    task: str
+    latest_total: int
+    version_rates: dict[str, float | None]
+    version_deltas: dict[str, float | None]
+
+
+@dataclass(frozen=True)
+class TrendReport:
+    """跨版本任务表现报告。"""
+
+    versions: list[str]
+    rows: list[TaskTrendRow]
+    task_filter: str | None = None
+    detailed_task_stats: list[VersionTaskStat] | None = None
+
+
+def format_delta(delta_pp: float | None) -> str:
+    """格式化百分点变化量,例如 '+1.4pp' 或 '-2.0pp'。"""
+    if delta_pp is None:
+        return ""
+    sign = "+" if delta_pp > 0 else ""
+    return f"{sign}{delta_pp:.1f}pp"
+
+
+def format_rate_with_delta(rate: float | None, delta_pp: float | None) -> str:
+    """把小数失败率格式化为百分比,并追加括号备注的百分点变化量。"""
+    if rate is None:
+        return "暂无样本"
+    base = f"{rate:.1%}"
+    delta = format_delta(delta_pp)
+    return f"{base} ({delta})" if delta else base
+
+
+def _unique_trace_count(row: dict[str, Any], key: str) -> int | None:
+    value = row.get(key)
+    return value if isinstance(value, int) else None
+
+
+def discover_versions(
+    rows: Sequence[dict[str, Any]],
+    *,
+    count: int = DEFAULT_VERSIONS_COUNT,
+    include_prerelease: bool = False,
+    min_users: int = MIN_RELEASE_UNIQUE_USERS,
+) -> list[str]:
+    """从 spans 中发现用户数达标的最近 N 个版本(降序排列)。
+
+    额外多探索一个版本以作为最老展示版本的变化量基准。
+    """
+    version_users: dict[tuple[int, int, int, int, int], int] = defaultdict(int)
+    version_labels: dict[tuple[int, int, int, int, int], str] = {}
+
+    for row in rows:
+        release = row.get("release")
+        user_count = row.get("count_unique(user)")
+        if not isinstance(release, str) or not isinstance(user_count, int):
+            continue
+        key = release_version_key(release)
+        label = version_label(release)
+        if key is None or label is None:
+            continue
+        # key[3] == 2 代表正式稳定版,0/1 分别为 beta/rc
+        if not include_prerelease and key[3] != 2:
+            continue
+        version_users[key] += user_count
+        version_labels[key] = label
+
+    qualified_keys = [key for key, users in sorted(version_users.items(), reverse=True) if users >= min_users]
+    # 取 count + 1 个版本,以提供最旧展示版本相对于更早版本的环比变化
+    selected_keys = qualified_keys[: count + 1]
+    return [version_labels[key] for key in selected_keys]
+
+
+def build_trend_report(
+    totals: Iterable[dict[str, Any]],
+    statuses: Iterable[dict[str, Any]],
+    versions: Sequence[str],
+    *,
+    task_filter: str | None = None,
+    min_latest_runs: int = DEFAULT_MIN_LATEST_RUNS,
+    sort: str = "runs",
+    reverse: bool = False,
+    limit: int | None = None,
+) -> TrendReport:
+    """根据执行与状态分布行聚合各版本的任务失败率及环比变化。"""
+    version_set = set(versions)
+    task_totals: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    task_failures: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    task_oks: dict[str, int] = defaultdict(int)
+
+    for row in totals:
+        release = str(row.get("release", ""))
+        label = version_label(release)
+        description = row.get("span.description")
+        count = _unique_trace_count(row, "count_unique(trace)")
+        if label in version_set and isinstance(description, str) and count:
+            task_totals[label][description] += count
+
+    for row in statuses:
+        release = str(row.get("release", ""))
+        label = version_label(release)
+        description = row.get("span.description")
+        status = row.get("span.status")
+        count = _unique_trace_count(row, "count_unique(trace)")
+        if label in version_set and isinstance(description, str) and count:
+            if status == INTERNAL_ERROR:
+                task_failures[label][description] += count
+            elif status == "ok":
+                task_oks[description] += count
+
+    all_tasks = set()
+    for v in version_set:
+        all_tasks.update(task_totals[v].keys())
+
+    # 若指定了单任务筛选,提取单任务在各个版本下的详细统计
+    detailed_stats: list[VersionTaskStat] | None = None
+    if task_filter:
+        target_task = next(
+            (t for t in all_tasks if task_filter.lower() in t.lower()),
+            task_filter,
+        )
+        detailed_stats = []
+        for i, version in enumerate(versions):
+            tot = task_totals[version].get(target_task, 0)
+            fail = task_failures[version].get(target_task, 0)
+            rate = (fail / tot) if tot > 0 else None
+
+            delta_pp: float | None = None
+            if i + 1 < len(versions):
+                prev_version = versions[i + 1]
+                prev_tot = task_totals[prev_version].get(target_task, 0)
+                prev_fail = task_failures[prev_version].get(target_task, 0)
+                if prev_tot > 0 and rate is not None:
+                    delta_pp = (rate - (prev_fail / prev_tot)) * 100
+
+            detailed_stats.append(
+                VersionTaskStat(
+                    version=version,
+                    total=tot,
+                    failed=fail,
+                    failure_rate=rate,
+                    delta_pp=delta_pp,
+                )
+            )
+
+    # 聚合全局任务宽表(排除 umbrella span 与纯失败节点标记)
+    latest_version = versions[0] if versions else ""
+    rows: list[TaskTrendRow] = []
+
+    for task in all_tasks:
+        if task_filter and task_filter.lower() not in task.lower():
+            continue
+        if (
+            task in SYSTEM_LABELS
+            or any(task.startswith(p) for p in CONFIG.ignored_prefixes)
+            or any(task.endswith(s) for s in CONFIG.ignored_suffixes)
+        ):
+            continue
+        # 若未显式筛选单任务,排除没有成功样本的纯失败节点标记(如 ReturnMain、Start1999 等)
+        if not task_filter and task_oks.get(task, 0) == 0:
+            continue
+
+        latest_total = task_totals[latest_version].get(task, 0)
+        # 仅保留在最新版本或任意版本中有足够样本的任务
+        any_total = sum(task_totals[v].get(task, 0) for v in versions)
+        if latest_total < min_latest_runs and any_total < min_latest_runs * 2:
+            continue
+
+        rates: dict[str, float | None] = {}
+        deltas: dict[str, float | None] = {}
+        for i, version in enumerate(versions):
+            tot = task_totals[version].get(task, 0)
+            fail = task_failures[version].get(task, 0)
+            rate = (fail / tot) if tot > 0 else None
+            rates[version] = rate
+
+            delta_pp: float | None = None
+            if i + 1 < len(versions):
+                prev_v = versions[i + 1]
+                prev_tot = task_totals[prev_v].get(task, 0)
+                prev_fail = task_failures[prev_v].get(task, 0)
+                if prev_tot > 0 and rate is not None:
+                    delta_pp = (rate - (prev_fail / prev_tot)) * 100
+            deltas[version] = delta_pp
+
+        rows.append(
+            TaskTrendRow(
+                task=task,
+                latest_total=latest_total,
+                version_rates=rates,
+                version_deltas=deltas,
+            )
+        )
+
+    if sort == "rate":
+        rows.sort(
+            key=lambda r: (
+                r.version_rates.get(latest_version) is not None,
+                r.version_rates.get(latest_version) or 0.0,
+                r.latest_total,
+            ),
+            reverse=not reverse,
+        )
+    elif sort == "delta":
+        rows.sort(
+            key=lambda r: (
+                r.version_deltas.get(latest_version) is not None,
+                r.version_deltas.get(latest_version) or 0.0,
+                r.latest_total,
+            ),
+            reverse=not reverse,
+        )
+    elif sort == "name":
+        rows.sort(key=lambda r: r.task, reverse=reverse)
+    else:  # "runs" (默认)
+        rows.sort(key=lambda r: (r.latest_total, r.task), reverse=not reverse)
+
+    if limit is not None and limit > 0:
+        rows = rows[:limit]
+
+    return TrendReport(
+        versions=list(versions),
+        rows=rows,
+        task_filter=task_filter,
+        detailed_task_stats=detailed_stats,
+    )
+
+
+def collect_report(
+    *,
+    sentry_command: str,
+    target: str,
+    period: str,
+    versions_count: int,
+    include_prerelease: bool,
+    task_filter: str | None,
+    min_latest_runs: int,
+    sort: str = "runs",
+    reverse: bool = False,
+    limit: int | None = None,
+    timeout_seconds: float,
+    verbose: bool,
+    quiet: bool,
+) -> TrendReport:
+    """查询 Sentry spans 并生成多版本任务对比报告。"""
+    show_progress(
+        f"[1/3] 探索最近 {versions_count} 个版本",
+        quiet=quiet,
+    )
+    version_discovery_rows = explore(
+        sentry_command,
+        target=target,
+        period=period,
+        fields=("release", "count_unique(user)", "count_unique(trace)"),
+        query="",
+        sort="-count_unique(user)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+    all_discovered = discover_versions(
+        version_discovery_rows,
+        count=versions_count,
+        include_prerelease=include_prerelease,
+    )
+    if not all_discovered:
+        raise RuntimeError(f"在 {period} 内未找到符合条件的应用版本(至少 {MIN_RELEASE_UNIQUE_USERS} 位独立用户)。")
+
+    # 展示的版本数与用于提供基准变化量的全量版本列表
+    display_versions = all_discovered[:versions_count]
+    query_versions = all_discovered
+    show_progress(
+        f"分析版本: {', '.join(display_versions)} (数据聚合覆盖各版本的所有渠道)",
+        quiet=quiet,
+    )
+
+    query_filter = f'span.description:"{task_filter}"' if task_filter else ""
+
+    show_progress("[2/3] 查询各版本任务执行总量", quiet=quiet)
+    totals = explore(
+        sentry_command,
+        target=target,
+        period=period,
+        fields=("span.description", "release", "count_unique(trace)"),
+        query=query_filter,
+        sort="-count_unique(trace)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+
+    show_progress("[3/3] 查询各版本任务结果分布", quiet=quiet)
+    statuses = explore(
+        sentry_command,
+        target=target,
+        period=period,
+        fields=("span.description", "span.status", "release", "count_unique(trace)"),
+        query=query_filter,
+        sort="-count_unique(trace)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+
+    report = build_trend_report(
+        totals,
+        statuses,
+        query_versions,
+        task_filter=task_filter,
+        min_latest_runs=min_latest_runs,
+        sort=sort,
+        reverse=reverse,
+        limit=limit,
+    )
+    # 仅展示用户指定的 display_versions
+    return TrendReport(
+        versions=display_versions,
+        rows=report.rows,
+        task_filter=task_filter,
+        detailed_task_stats=(
+            [s for s in report.detailed_task_stats if s.version in display_versions]
+            if report.detailed_task_stats
+            else None
+        ),
+    )
+
+
+def write_console(report: TrendReport, output: TextIO) -> None:
+    if report.detailed_task_stats:
+        task_name = report.task_filter or "指定任务"
+        print(f"任务趋势明细: {task_name}", file=output)
+        print("所有次数均按唯一 trace 去重,变化量为相对上一版本的百分点差异(Δpp)。\n", file=output)
+        headers = ("版本", "运行数", "失败数", "失败率", "相对上一版本")
+        rows = [
+            (
+                stat.version,
+                str(stat.total),
+                str(stat.failed),
+                f"{stat.failure_rate:.1%}" if stat.failure_rate is not None else "暂无样本",
+                format_delta(stat.delta_pp) if stat.delta_pp is not None else "-",
+            )
+            for stat in report.detailed_task_stats
+        ]
+        write_console_table(headers, rows, output, right_aligned={1, 2, 3, 4})
+        return
+
+    print("任务失败率跨版本对比 (含相对上一版本的变化量)", file=output)
+    print(
+        "括号内备注为相对上一版本的百分点变化(如 -1.4pp 表示失败率下降 1.4%);运行数按唯一 trace 去重。\n", file=output
+    )
+
+    latest_ver = report.versions[0] if report.versions else "最新"
+    headers = ["任务", f"运行数({latest_ver})", *report.versions]
+    table_rows = []
+    for row in report.rows:
+        cells = [row.task, str(row.latest_total)]
+        for v in report.versions:
+            rate = row.version_rates.get(v)
+            delta = row.version_deltas.get(v)
+            cells.append(format_rate_with_delta(rate, delta))
+        table_rows.append(cells)
+
+    right_aligned = set(range(1, len(headers)))
+    write_console_table(headers, table_rows, output, right_aligned=right_aligned)
+
+
+def write_markdown(report: TrendReport, output: TextIO) -> None:
+    if report.detailed_task_stats:
+        task_name = report.task_filter or "指定任务"
+        print(f"## 任务趋势明细: {task_name}\n", file=output)
+        print("> 所有次数均按唯一 trace 去重,变化量为相对上一版本的百分点差异(Δpp)。\n", file=output)
+        print("| 版本 | 运行数 | 失败数 | 失败率 | 相对上一版本 |", file=output)
+        print("|---|---:|---:|---:|---:|", file=output)
+        for stat in report.detailed_task_stats:
+            rate_str = f"{stat.failure_rate:.1%}" if stat.failure_rate is not None else "暂无样本"
+            delta_str = format_delta(stat.delta_pp) if stat.delta_pp is not None else "-"
+            print(f"| {stat.version} | {stat.total} | {stat.failed} | {rate_str} | {delta_str} |", file=output)
+        return
+
+    print("## 任务失败率跨版本对比 (含相对上一版本的变化量)\n", file=output)
+    print("> 括号内备注为相对上一版本的百分点变化(如 `-1.4pp` 表示失败率下降 1.4%)。\n", file=output)
+    latest_ver = report.versions[0] if report.versions else "最新"
+    headers = ["任务", f"运行数({latest_ver})", *report.versions]
+    header_line = "| " + " | ".join(headers) + " |"
+    separator_line = "|---|" + "|".join("---:" for _ in headers[1:]) + "|"
+    print(header_line, file=output)
+    print(separator_line, file=output)
+
+    for row in report.rows:
+        cells = [row.task, str(row.latest_total)]
+        for v in report.versions:
+            rate = row.version_rates.get(v)
+            delta = row.version_deltas.get(v)
+            cells.append(format_rate_with_delta(rate, delta))
+        print("| " + " | ".join(cells) + " |", file=output)
+
+
+def write_json(report: TrendReport, output: TextIO) -> None:
+    json.dump(asdict(report), output, ensure_ascii=False, indent=2)
+    output.write("\n")
+
+
+def create_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description=__doc__)
+    parser.add_argument(
+        "--versions",
+        type=int,
+        default=DEFAULT_VERSIONS_COUNT,
+        help=f"对比最近 N 个版本(默认:{DEFAULT_VERSIONS_COUNT})",
+    )
+    parser.add_argument(
+        "--task",
+        help="指定查看某一具体任务的详细版本走势(如 --task 领取奖励)",
+    )
+    parser.add_argument("--target", default=DEFAULT_TARGET, help="<org>/<project>")
+    parser.add_argument(
+        "--period",
+        default=DEFAULT_RELEASE_DISCOVERY_PERIOD,
+        help="查询范围(默认:90d),以覆盖多个版本的生命周期",
+    )
+    parser.add_argument(
+        "--include-beta",
+        action="store_true",
+        help="版本序列中包含 beta/rc 测试版(默认仅对比正式稳定版)",
+    )
+    parser.add_argument(
+        "--min-latest-runs",
+        type=int,
+        default=DEFAULT_MIN_LATEST_RUNS,
+        help=f"在大表中展示任务所需的最低样本数(默认:{DEFAULT_MIN_LATEST_RUNS})",
+    )
+    parser.add_argument(
+        "--sort",
+        choices=("runs", "rate", "delta", "name"),
+        default="runs",
+        help="任务排序规则: runs(运行数从大到小,默认), rate(失败率从高到低), delta(恶化幅度从大到小), name(任务名)",
+    )
+    parser.add_argument(
+        "--reverse",
+        action="store_true",
+        help="反转排序顺序(例如失败率从低到高)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="限制展示的任务数量(如 --limit 10 仅展示前 10 个任务)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("console", "markdown", "json"),
+        default="console",
+        help="输出格式",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_SENTRY_TIMEOUT_SECONDS,
+        help="单次 Sentry 查询超时秒数(默认:120)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="输出 sentry 查询命令")
+    parser.add_argument("--quiet", action="store_true", help="不输出查询进度")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+
+    arguments = create_argument_parser(prog).parse_args(argv)
+    if not math.isfinite(arguments.timeout) or arguments.timeout <= 0:
+        raise ValueError("--timeout 必须是大于 0 的有限数值。")
+    if arguments.versions <= 0:
+        raise ValueError("--versions 必须是大于 0 的整数。")
+    if arguments.limit is not None and arguments.limit <= 0:
+        raise ValueError("--limit 必须是大于 0 的整数。")
+
+    report = collect_report(
+        sentry_command=resolve_sentry_command(),
+        target=arguments.target,
+        period=arguments.period,
+        versions_count=arguments.versions,
+        include_prerelease=arguments.include_beta,
+        task_filter=arguments.task,
+        min_latest_runs=arguments.min_latest_runs,
+        sort=arguments.sort,
+        reverse=arguments.reverse,
+        limit=arguments.limit,
+        timeout_seconds=arguments.timeout,
+        verbose=arguments.verbose,
+        quiet=arguments.quiet,
+    )
+    writers = {
+        "console": write_console,
+        "markdown": write_markdown,
+        "json": write_json,
+    }
+    writers[arguments.format](report, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (FileNotFoundError, RuntimeError, ValueError) as error:
+        print(f"错误:{error}", file=sys.stderr)
+        raise SystemExit(1) from error


### PR DESCRIPTION
## Summary

为 MaaFramework 应用引入通用的 Sentry 遥测数据分析与质量监控工具套件，支持单版本任务健康度排查与跨版本稳定性走势分析：

1. **`task-trend`（跨版本趋势与回归对比）**：
   - 支持跨多版本统计任务失败率走势；
   - 自动计算并在括号中展示相比上一版本的百分点环比变化量（如 `21.6% (+12.7pp)`、`3.9% (-2.0pp)`）；
   - 支持 `--sort {runs,rate,delta,name}`，支持按恶化幅度（`--sort delta`）快速揪出版本负向回归；
   - 支持 `--limit N`、`--reverse`、`--task <任务名>` 单任务穿透模式以及 `--format {console,markdown,json}`。

2. **`task-failure`（单版本任务失败率深度分析）**：
   - 分析最新或指定版本的全任务失败率分布，自动过滤纯失败系统节点；
   - 展现失败节点标记与各渠道 Umbrella Span 运行失败率；
   - 支持 `--sort {failures,rate,total,name}` 与 `--limit N`，全部基于 Sentry 服务端聚合极速输出。

3. **通用化配置与解耦**：
   - 引入 `tools/sentry/config.json`，无缝支持其他 MaaFW 项目（如 MaaEnd、MAA 等）一键接入，代码无硬编码默认值；
   - 增加详尽的 `tools/sentry/README.md`（面向人类开发者）与 `.agents/skills/maafw-sentry-analysis/SKILL.md`（面向 AI Agent）。

## Verification
- `pnpm format && pnpm check` 通过；
- `pnpm check:py`（Ruff + Pyright strict + 151 项 Pytest）全量通过。

## Sourcery 摘要

新增可配置的 MaaFramework Sentry 遥测报告，用于诊断版本发布健康状况并识别跨版本任务回归问题。

新功能：
- 为单个 MaaFramework 版本发布新增基于 Sentry 的任务失败分析，包括任务失败分布、失败标记和渠道级运行健康状况。
- 新增跨版本任务趋势报告，支持百分点变化、面向回归问题的排序、任务下钻，以及控制台、Markdown 和 JSON 输出格式。
- 支持配置项目和版本发布约定，使分析工具可复用于多个 MaaFramework 应用。

增强功能：
- 在共享工具中集中处理 Sentry 查询、版本发布发现、版本解析、分页，以及支持 Unicode 的报告格式化。
- 提供统一的命令行入口，支持版本发布发现、筛选、排序、数量限制、超时和进度控制。

文档：
- 为开发者和 AI 代理补充安装、身份验证、使用方法、报告解读以及跨项目配置文档。

测试：
- 新增全面的测试覆盖，包括版本发布解析与选择、配置验证、任务和版本发布聚合、趋势计算、排序、筛选、格式化以及 CLI 行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

引入可配置的 Sentry 遥测报告，用于诊断 MaaFramework 的发布健康状况，并检测不同版本之间的任务回归问题。

新功能：
- 添加基于 Sentry 的单版本任务失败分析，包括任务分布、失败标记以及按渠道统计的运行健康指标。
- 添加跨版本任务趋势报告，支持百分点变化、面向回归问题的排序、任务详细分析，以及控制台、Markdown 或 JSON 输出。

增强功能：
- 通过经过验证的项目配置，而不是硬编码的项目和发布约定，使 Sentry 分析可在不同 MaaFramework 应用之间复用。
- 在共享报告工具中集中实现 Sentry 查询、发布版本发现与解析、分页、Unicode 表格格式化以及 CLI 控制。

文档：
- 为开发者和 AI 代理记录安装、身份验证、命令使用、结果解读以及跨项目配置。

测试：
- 添加对发布版本解析与选择、配置验证、聚合、趋势计算、排序、筛选、格式化和 CLI 行为的全面测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入可配置的 Sentry 遥测报告，用于诊断 MaaFramework 的发布健康状况，并检测不同版本之间的任务回归问题。

新功能：
- 添加基于 Sentry 的单版本任务失败分析，包括任务分布、失败标记以及频道级运行健康指标。
- 添加跨版本任务趋势分析，包括百分点差异、面向回归问题的排序、任务下钻，以及控制台、Markdown 或 JSON 输出。

增强：
- 通过经过验证的项目配置，使报告能够在不同 MaaFramework 应用之间复用，而不再依赖硬编码的发布约定。
- 集中处理 Sentry 查询、版本发现与解析、分页、支持 Unicode 的表格格式化，以及共享的 CLI 控制项。

文档：
- 记录安装、身份验证、命令用法、指标解读、跨项目配置，以及用于 Sentry 分析的 AI 智能体工作流。

测试：
- 为版本解析与选择、配置验证、聚合、趋势计算、排序、筛选、格式化和 CLI 行为添加全面的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable Sentry telemetry reports for diagnosing MaaFramework release health and detecting task regressions across versions.

New Features:
- Add Sentry-based single-version task failure analysis with task distributions, failure markers, and channel-level run health metrics.
- Add cross-version task trend analysis with percentage-point deltas, regression-focused sorting, task drill-down, and console, Markdown, or JSON output.

Enhancements:
- Make the reports reusable across MaaFramework applications through validated project configuration instead of hard-coded release conventions.
- Centralize Sentry querying, release discovery and parsing, pagination, Unicode-aware table formatting, and shared CLI controls.

Documentation:
- Document installation, authentication, command usage, metric interpretation, cross-project configuration, and AI-agent workflows for Sentry analysis.

Tests:
- Add comprehensive coverage for release parsing and selection, configuration validation, aggregation, trend calculations, sorting, filtering, formatting, and CLI behavior.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 Sentry 任务失败率分析工具，支持单版本分析及多版本趋势对比。
  - 支持控制台、Markdown 和 JSON 报告，并提供任务筛选、排序、版本及时间范围选项。
  - 报告区分任务结果、失败节点和运行失败率，展示失败率及版本间百分点变化。
  - 支持多渠道版本聚合及更严格的配置校验和错误提示。
- **文档**
  - 新增安装、认证、配置和报告使用指南，支持跨项目配置。
- **测试**
  - 新增报告生成、命令行参数、版本筛选和配置校验测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->